### PR TITLE
Create five new typescript documentation articles

### DIFF
--- a/docs/typescript/01-basics/03-type-system-basics.md
+++ b/docs/typescript/01-basics/03-type-system-basics.md
@@ -1,0 +1,88 @@
+# 型システムの基礎
+
+TypeScript は構造的部分型（structural typing）に基づいた静的型付け言語です。ここでは「型注釈」「型推論」「代入互換性」「トップ/ボトム型」「null/undefined」「絞り込み（narrowing）」の基礎を押さえます。
+
+## 型注釈と型推論
+
+```ts
+let count: number = 0;      // 型注釈
+const title = "Hello";      // 型推論 => string
+```
+
+- 明示的に注釈を書くのは「公開 API」や「複雑な式」で有効。
+- ローカル変数は可能な限り推論に任せて簡潔に。
+
+## 構造的部分型と代入互換性
+
+型の互換性は「メンバーの形」で判断されます。
+
+```ts
+type Point = { x: number; y: number };
+const p: Point = { x: 1, y: 2, z: 3 }; // 追加プロパティがあっても代入は可能（変数経由の場合）
+```
+
+ただしリテラル直接代入時には「過剰プロパティチェック」が働きます。
+
+```ts
+// エラー: オブジェクトリテラルを直接代入すると余計な z がチェックされる
+const p2: Point = { x: 1, y: 2, z: 3 };
+
+// 回避: 変数にいったん格納する
+const tmp = { x: 1, y: 2, z: 3 };
+const p3: Point = tmp; // OK
+```
+
+## Top/Bottom 型: any, unknown, never
+
+- any: 何でも可。安全性を下げるので最小限に。
+- unknown: 「何か」だが使うには絞り込みが必要。安全。
+- never: 到達不能・値が存在しない型（例: 常に例外を投げる関数）
+
+```ts
+function fail(message: string): never {
+  throw new Error(message);
+}
+```
+
+## null と undefined, strictNullChecks
+
+`strictNullChecks` が有効だと `null` と `undefined` は明示的に扱う必要があります。
+
+```ts
+let name: string | undefined;
+if (name !== undefined) {
+  console.log(name.toUpperCase());
+}
+```
+
+## 絞り込み (Narrowing) と制御フロー解析
+
+`typeof`, `in`, `instanceof`, リテラル比較などで型を絞り込みます。
+
+```ts
+function printId(id: string | number) {
+  if (typeof id === "string") {
+    console.log(id.toUpperCase());
+  } else {
+    console.log(id.toFixed(2));
+  }
+}
+```
+
+ユーザー定義タイプガードも使えます。
+
+```ts
+type Fish = { swim: () => void };
+type Bird = { fly: () => void };
+
+function isFish(animal: Fish | Bird): animal is Fish {
+  return (animal as Fish).swim !== undefined;
+}
+```
+
+## まとめ
+
+- 型注釈は公開面、推論は実装面で活用
+- 構造的部分型と過剰プロパティチェックの違いを理解
+- `unknown` を優先し、`any` は最後の手段
+- 絞り込みで安全に分岐・アクセス

--- a/docs/typescript/01-basics/04-primitive-and-literal-types.md
+++ b/docs/typescript/01-basics/04-primitive-and-literal-types.md
@@ -14,6 +14,19 @@ const bi: bigint = 10n;
 const sym: symbol = Symbol("id");
 ```
 
+### number の注意点
+
+- `NaN` は `number`。比較は常に false（`NaN !== NaN`）。`Number.isNaN` を使用。
+- 数値区切り: `1_000_000` は可読性向上。
+
+### bigint の注意点
+
+- `number` と混在演算不可。`BigInt(1)` などで変換する。
+
+### symbol の注意点
+
+- `Symbol()` は一意。`Symbol.for(key)` はグローバルレジストリ共有。
+
 `null` と `undefined` は `strictNullChecks` 有効時にユニオンで明示します。
 
 ```ts
@@ -38,16 +51,51 @@ type OneOrZero = 0 | 1;
 const flag: true = true;
 ```
 
+### リテラルの拡大（widening）
+
+`let x = "a"` は `string` に拡大。拡大を防ぎたい場合は `const` または `as const` を使用。
+
+```ts
+let x = "a";     // string
+const y = "a";   // "a"
+
+const cfg = { mode: "dev" };         // mode: string
+const cfg2 = { mode: "dev" } as const; // mode: "dev"
+```
+
 ## const アサーション
 
-`as const` でリテラル型へ固定できます。
+`as const` でリテラル型へ固定できます。配列やオブジェクトは深く `readonly` になります。
 
 ```ts
 const CONFIG = {
   mode: "dev",
   retries: 3,
-} as const; // mode は "dev"、retries は 3 のリテラル型
+} as const; // mode は "dev"、retries は 3 のリテラル型、かつ readonly
 ```
+
+## テンプレートリテラル型（入門）
+
+文字列の形を型で表現できます。
+
+```ts
+type Env = "dev" | "prod";
+type Endpoint = `/api/${Env}/${string}`;
+const e: Endpoint = "/api/dev/users"; // OK
+```
+
+## Enum よりリテラルユニオン
+
+多くのケースでは `enum` よりユニオン型が軽量で相互運用性が高い。
+
+```ts
+type Role = "admin" | "user" | "guest";
+```
+
+## 代表的な落とし穴
+
+- `toString()` を `null/undefined` に対して呼ぶとクラッシュ。ユニオンで扱う。
+- `parseInt` は基数を指定（`parseInt("08", 10)`）。数値化は `Number()` も検討。
 
 ## リテラルの絞り込み
 
@@ -65,6 +113,6 @@ function render(status: Status) {
 
 ## まとめ
 
-- プリミティブ型は基本の土台
-- リテラル型で許容値を厳密に
-- `as const` で安全に固定
+- プリミティブ型の挙動（NaN, bigint, symbol）を理解
+- リテラル型で許容値を厳密に、拡大を制御
+- `as const` とテンプレートリテラル型で表現力を高める

--- a/docs/typescript/01-basics/04-primitive-and-literal-types.md
+++ b/docs/typescript/01-basics/04-primitive-and-literal-types.md
@@ -1,0 +1,70 @@
+# プリミティブ型とリテラル型
+
+## プリミティブ型
+
+- string, number, boolean
+- bigint, symbol
+- null, undefined
+
+```ts
+const s: string = "text";
+const n: number = 1.23;
+const b: boolean = false;
+const bi: bigint = 10n;
+const sym: symbol = Symbol("id");
+```
+
+`null` と `undefined` は `strictNullChecks` 有効時にユニオンで明示します。
+
+```ts
+let name: string | undefined;
+let maybe: number | null;
+```
+
+## リテラル型
+
+特定の値だけを許容する型です。
+
+```ts
+let direction: "up" | "down";
+direction = "up";   // OK
+direction = "left"; // エラー
+```
+
+数値や boolean も同様です。
+
+```ts
+type OneOrZero = 0 | 1;
+const flag: true = true;
+```
+
+## const アサーション
+
+`as const` でリテラル型へ固定できます。
+
+```ts
+const CONFIG = {
+  mode: "dev",
+  retries: 3,
+} as const; // mode は "dev"、retries は 3 のリテラル型
+```
+
+## リテラルの絞り込み
+
+比較で自然に絞り込みます。
+
+```ts
+type Status = "idle" | "loading" | "success" | "error";
+
+function render(status: Status) {
+  if (status === "loading") {
+    // status は "loading"
+  }
+}
+```
+
+## まとめ
+
+- プリミティブ型は基本の土台
+- リテラル型で許容値を厳密に
+- `as const` で安全に固定

--- a/docs/typescript/01-basics/05-object-types-and-interfaces.md
+++ b/docs/typescript/01-basics/05-object-types-and-interfaces.md
@@ -1,0 +1,55 @@
+# オブジェクト型とインターフェース
+
+## 基本のオブジェクト型
+
+```ts
+type User = {
+  id: string;
+  name?: string;       // 任意プロパティ
+  readonly role: "admin" | "user"; // 読み取り専用
+};
+```
+
+## type と interface の使い分け
+
+- interface: 拡張（extends）や宣言マージが可能
+- type: ユニオン・インターセクションに強い、表現力が広い
+
+```ts
+interface Animal { name: string }
+interface Dog extends Animal { bark(): void }
+
+type A = { x: number } & { y: number }; // 交差（インターセクション）
+```
+
+## インデックスシグネチャとレコード
+
+```ts
+type StringMap = { [key: string]: string };
+const env: Record<string, string> = { NODE_ENV: "development" };
+```
+
+## 過剰プロパティチェック
+
+オブジェクトリテラルを直接代入すると追加プロパティがチェックされます。変数経由なら緩やかになります。
+
+```ts
+type Point = { x: number; y: number };
+const p1: Point = { x: 0, y: 0, z: 1 }; // エラー
+const tmp = { x: 0, y: 0, z: 1 };
+const p2: Point = tmp; // OK
+```
+
+## 宣言マージ（interface）
+
+```ts
+interface Window { appVersion: string }
+interface Window { user?: string }
+// → Window は { appVersion: string; user?: string } へマージ
+```
+
+## まとめ
+
+- `interface` は拡張やマージに強い
+- `type` はユニオン/交差や複合的表現に強い
+- 読み取り専用、任意、インデックスなど修飾子を活用

--- a/docs/typescript/01-basics/05-object-types-and-interfaces.md
+++ b/docs/typescript/01-basics/05-object-types-and-interfaces.md
@@ -29,6 +29,8 @@ type StringMap = { [key: string]: string };
 const env: Record<string, string> = { NODE_ENV: "development" };
 ```
 
+キープロパティ型は `string | number | symbol` のいずれか。数値キーは内部的に文字列化される点に注意。
+
 ## 過剰プロパティチェック
 
 オブジェクトリテラルを直接代入すると追加プロパティがチェックされます。変数経由なら緩やかになります。
@@ -48,8 +50,64 @@ interface Window { user?: string }
 // → Window は { appVersion: string; user?: string } へマージ
 ```
 
+## ユーティリティ型で設計を簡潔に
+
+```ts
+type Profile = { id: string; name: string; email?: string };
+
+type ReadonlyProfile = Readonly<Profile>;
+type PartialProfile = Partial<Profile>;
+type RequiredProfile = Required<Profile>;
+type PublicProfile = Pick<Profile, "id" | "name">;
+type PrivateProfile = Omit<Profile, "name">;
+```
+
+`Record<K, T>` は「キー集合 K から値 T」へマップする型。`NonNullable<T>` や `ReturnType<F>` も頻出。
+
+## 可変性と readonly の使い分け
+
+- 変更を禁止したい公開 API では `readonly` を積極的に
+- 内部実装ではミュータブルでも良いが、返すときに `Readonly<T>` で包む
+
+## オプショナルと `undefined` の違い
+
+- `name?: string` は「存在しない」か「存在して string」
+- `name: string | undefined` は「必ずキーはあるが値は undefined 可」
+
+```ts
+type A = { name?: string };
+type B = { name: string | undefined };
+```
+
+## 判別可能ユニオンの設計
+
+```ts
+type Event =
+  | { type: "click"; x: number; y: number }
+  | { type: "keydown"; key: string };
+
+function handle(e: Event) {
+  if (e.type === "click") {
+    e.x; // OK
+  }
+}
+```
+
+## ジェネリックなインターフェース
+
+```ts
+interface Box<T> { value: T }
+const sBox: Box<string> = { value: "hi" };
+```
+
+## ベストプラクティス
+
+- DTO など外部公開の型は `readonly` で防御的に
+- `any` より `unknown`、型ガードで絞り込む
+- `Object` や `{}` より具象的な形を定義
+
 ## まとめ
 
 - `interface` は拡張やマージに強い
 - `type` はユニオン/交差や複合的表現に強い
-- 読み取り専用、任意、インデックスなど修飾子を活用
+- ユーティリティ型と判別可能ユニオンで保守性を高める

--- a/docs/typescript/01-basics/06-arrays-and-tuples.md
+++ b/docs/typescript/01-basics/06-arrays-and-tuples.md
@@ -20,6 +20,16 @@ const ys: ReadonlyArray<number> = [1, 2, 3];
 [1, 2, 3].map(n => n * 2); // number[]
 ```
 
+### ミュータブル vs イミュータブル操作
+
+- `push`, `splice` はミュータブル。
+- `map`, `filter`, `concat`, スプレッドはイミュータブルに新配列を返す。
+
+```ts
+const a = [1, 2];
+const b = [...a, 3]; // a は不変、b は [1,2,3]
+```
+
 ## タプル型
 
 位置と長さが固定された配列です。
@@ -28,7 +38,14 @@ const ys: ReadonlyArray<number> = [1, 2, 3];
 const pair: [number, string] = [1, "one"];
 ```
 
-可変長（variadic）なタプルも使えます。
+### タプルのラベルと分割代入
+
+```ts
+const point: [x: number, y: number] = [10, 20];
+const [x, y] = point; // x: number, y: number
+```
+
+### 可変長（variadic）タプル
 
 ```ts
 function concat<T extends unknown[]>(...xs: T): T {
@@ -38,14 +55,33 @@ function concat<T extends unknown[]>(...xs: T): T {
 const t = concat(1, "a", true); // [number, string, boolean]
 ```
 
+先頭・末尾へ要素を追加する表現も可能です。
+
+```ts
+type Push<T extends unknown[], U> = [...T, U];
+
+type T1 = Push<[1, 2], 3>; // [1, 2, 3]
+```
+
+### `as const` と readonly タプル
+
 `as const` でタプルのリテラルを厳密化できます。
 
 ```ts
 const POINT = [0, 0] as const; // readonly [0, 0]
 ```
 
+### タプル長の推論
+
+`as const` がないと配列リテラルは `number[]` などへ拡大し、長さ情報が失われます。
+
+```ts
+const rgb = [255, 255, 255];        // number[]
+const rgbTuple = [255, 255, 255] as const; // readonly [255, 255, 255]
+```
+
 ## まとめ
 
 - `T[]` と `Array<T>` は同義
 - 読み取り専用配列で不変性を高める
-- タプルで位置情報を表現し、必要に応じて可変長も活用
+- タプルで位置情報を表現し、variadic と `as const` を活用

--- a/docs/typescript/01-basics/06-arrays-and-tuples.md
+++ b/docs/typescript/01-basics/06-arrays-and-tuples.md
@@ -1,0 +1,51 @@
+# 配列とタプル型
+
+## 配列の型注釈
+
+```ts
+const numbers: number[] = [1, 2, 3];
+const strings: Array<string> = ["a", "b"]; // 同義
+```
+
+`readonly` 配列も用意されています。
+
+```ts
+const xs: readonly number[] = [1, 2, 3];
+const ys: ReadonlyArray<number> = [1, 2, 3];
+```
+
+配列メソッドはジェネリクスで型安全に扱えます。
+
+```ts
+[1, 2, 3].map(n => n * 2); // number[]
+```
+
+## タプル型
+
+位置と長さが固定された配列です。
+
+```ts
+const pair: [number, string] = [1, "one"];
+```
+
+可変長（variadic）なタプルも使えます。
+
+```ts
+function concat<T extends unknown[]>(...xs: T): T {
+  return xs;
+}
+
+const t = concat(1, "a", true); // [number, string, boolean]
+```
+
+`as const` でタプルのリテラルを厳密化できます。
+
+```ts
+const POINT = [0, 0] as const; // readonly [0, 0]
+```
+
+## まとめ
+
+- `T[]` と `Array<T>` は同義
+- 読み取り専用配列で不変性を高める
+- タプルで位置情報を表現し、必要に応じて可変長も活用

--- a/docs/typescript/01-basics/07-function-types-and-overloads.md
+++ b/docs/typescript/01-basics/07-function-types-and-overloads.md
@@ -42,7 +42,16 @@ function parse(input: string | number): string | number {
 }
 ```
 
-実装は 1 つで、先に宣言したオーバーロードの組み合わせを満たす必要があります。
+実装は 1 つで、先に宣言したオーバーロードの組み合わせを満たす必要があります。具体的なシグネチャを先に、汎用を後に並べます。
+
+## オーバーロードの代替: パラメータオブジェクト/ユニオン
+
+```ts
+type ParseOptions = { radix?: number };
+function parse2(input: string | number, opts?: ParseOptions) {
+  return typeof input === "string" ? Number.parseInt(input, opts?.radix) : String(input);
+}
+```
 
 ## ジェネリック関数
 
@@ -54,8 +63,52 @@ function identity<T>(value: T): T {
 const x = identity(42); // T=number
 ```
 
+### 条件付き戻り値の表現（簡易）
+
+```ts
+function maybeArray<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value];
+}
+```
+
+## ユーザー定義タイプガードと assertion
+
+```ts
+type Fish = { swim: () => void };
+function isFish(x: unknown): x is Fish {
+  return typeof (x as any)?.swim === "function";
+}
+
+function assertIsFish(x: unknown): asserts x is Fish {
+  if (!isFish(x)) throw new Error("Not a Fish");
+}
+```
+
+- `x is T` は分岐内で絞り込み
+- `asserts x is T` は失敗時に例外、成功時に以降の型が `T` として扱われる
+
+## 関数の変性とコールバックの安全性
+
+`--strictFunctionTypes` が無効だと、コールバック引数が双変（bivariant）になり危険な代入が通ることがあります。可能なら有効化しましょう。
+
+```ts
+interface Animal { name: string }
+interface Dog extends Animal { bark(): void }
+
+type Handler = (a: Animal) => void;
+const handleDog: (d: Dog) => void = () => {};
+
+let h: Handler = handleDog; // 非 strictFunctionTypes 下で許容され得る
+```
+
+## よくある落とし穴
+
+- オーバーロードの実装シグネチャにユニオンを使うが、戻り値の絞り込みを忘れる
+- メソッドを変数へ取り出すと `this` が失われる。`this` パラメータの注釈や `bind` を使う
+- 可変長引数で `any[]` を使わず、ジェネリクスのタプルを活用
+
 ## まとめ
 
-- 関数シグネチャを型で表す
-- オーバーロードは宣言（複数）+ 実装（1つ）
-- ジェネリックで再利用性と型安全性を両立
+- 関数シグネチャを型で表し、ガード/アサートで安全に絞る
+- オーバーロードは「具体→汎用」の順で宣言
+- 変性ルールを理解し、strict モードで安全性を高める

--- a/docs/typescript/01-basics/07-function-types-and-overloads.md
+++ b/docs/typescript/01-basics/07-function-types-and-overloads.md
@@ -1,0 +1,61 @@
+# 関数型とオーバーロード
+
+## 関数の型注釈
+
+```ts
+// 署名
+type Formatter = (value: number) => string;
+
+const format: Formatter = (v) => v.toFixed(2);
+```
+
+引数の任意・デフォルト・残余も型で表現します。
+
+```ts
+function greet(name: string, suffix: string = "!") {
+  return `Hello, ${name}${suffix}`;
+}
+
+function sum(...nums: number[]) {
+  return nums.reduce((a, b) => a + b, 0);
+}
+```
+
+`this` パラメータの注釈（最初のダミー引数）も可能です。
+
+```ts
+function fn(this: { id: string }) {
+  return this.id;
+}
+```
+
+## オーバーロード
+
+複数の呼び出しシグネチャを持つ関数を定義できます。
+
+```ts
+function parse(input: string): number;
+function parse(input: number): string;
+function parse(input: string | number): string | number {
+  if (typeof input === "string") return Number(input);
+  return String(input);
+}
+```
+
+実装は 1 つで、先に宣言したオーバーロードの組み合わせを満たす必要があります。
+
+## ジェネリック関数
+
+```ts
+function identity<T>(value: T): T {
+  return value;
+}
+
+const x = identity(42); // T=number
+```
+
+## まとめ
+
+- 関数シグネチャを型で表す
+- オーバーロードは宣言（複数）+ 実装（1つ）
+- ジェネリックで再利用性と型安全性を両立

--- a/docs/typescript/index.md
+++ b/docs/typescript/index.md
@@ -4,11 +4,11 @@
 
 - [x] [TypeScriptのインストールとセットアップ](./01-basics/01-typescript-setup.md)
 - [x] [TypeScriptの基本構文](./01-basics/02-typescript-syntax.md)
-- [ ] [型システムの基礎]
-- [ ] [プリミティブ型とリテラル型]
-- [ ] [オブジェクト型とインターフェース]
-- [ ] [配列とタプル型]
-- [ ] [関数型とオーバーロード]
+- [x] [型システムの基礎](./01-basics/03-type-system-basics.md)
+- [x] [プリミティブ型とリテラル型](./01-basics/04-primitive-and-literal-types.md)
+- [x] [オブジェクト型とインターフェース](./01-basics/05-object-types-and-interfaces.md)
+- [x] [配列とタプル型](./01-basics/06-arrays-and-tuples.md)
+- [x] [関数型とオーバーロード](./01-basics/07-function-types-and-overloads.md)
 - [ ] [ユニオン型とインターセクション型]
 - [ ] [型エイリアスとタイプガード]
 - [ ] [ジェネリクスの基礎]


### PR DESCRIPTION
Add five new TypeScript basic articles and update `index.md` to link them.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ae41cc2-9c1a-4aad-b9c8-36c3e9fa4980">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ae41cc2-9c1a-4aad-b9c8-36c3e9fa4980">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

