### PR TITLE
Add three articles to docs/ai/index.md

### DIFF
--- a/docs/ai/index.md
+++ b/docs/ai/index.md
@@ -14,3 +14,6 @@ AIに関する技術記事です。
 - [x] [AIアプリケーションにおけるベクトルデータベースの活用法：類似検索とRAGの実現](/ai/08-vector-db-for-ai-applications)
 - [x] [PyTorch vs. TensorFlow：2024年版 詳細比較とユースケース別使い分け](/ai/09-pytorch-vs-tensorflow-2024)
 - [x] [AIコードアシスタントを使いこなす：GitHub Copilotとその他ツールの比較、及びチーム導入のベストプラクティス](/ai/10-mastering-ai-code-assistants)
+- [x] [LLM評価とモニタリング：品質指標、観測性、A/Bテスト](/ai/11-llm-evaluation-and-observability)
+- [x] [画像生成モデル拡張：ControlNetとLoRAによる効率的チューニング](/ai/12-controlnet-lora-efficient-tuning)
+- [x] [エージェントシステム入門：ツール利用、計画、メモリ設計](/ai/13-agent-systems-introduction)


### PR DESCRIPTION
Add three new articles to `docs/ai/index.md` to expand the documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-34f7c186-e2da-45d6-9c14-3b2f42ec46d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34f7c186-e2da-45d6-9c14-3b2f42ec46d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

