### PR TITLE
docs: 5つの新しいTypeScriptの記事を作成・執筆

### DIFF
--- a/docs/typescript/01-basics/08-union-and-intersection-types.md
+++ b/docs/typescript/01-basics/08-union-and-intersection-types.md
@@ -1,0 +1,130 @@
+# ユニオン型とインターセクション型
+
+TypeScriptでは、既存の型を組み合わせて新しい型を作成するための強力な機能として、ユニオン型（Union Types）とインターセクション型（Intersection Types）が提供されています。
+
+## ユニオン型 (Union Types)
+
+ユニオン型は、複数の型のうちのいずれか一つであることを許容する型です。縦棒 (`|`) を使って型を区切ります。
+
+### 基本的な使い方
+
+ある変数が `string` または `number` のいずれかの型を受け入れるようにしたい場合、ユニオン型が役立ちます。
+
+```typescript
+function printId(id: number | string) {
+  console.log("Your ID is: " + id);
+}
+
+// OK
+printId(101);
+
+// OK
+printId("202");
+
+// Error
+// Argument of type '{ myID: number; }' is not assignable to parameter of type 'string | number'.
+// printId({ myID: 22342 });
+```
+
+### ユニオン型のプロパティへのアクセス
+
+ユニオン型の変数のプロパティやメソッドにアクセスする場合、そのユニオンを構成する**すべての型に共通して存在する**メンバーにしかアクセスできません。
+
+```typescript
+interface Bird {
+  fly(): void;
+  layEggs(): void;
+}
+
+interface Fish {
+  swim(): void;
+  layEggs(): void;
+}
+
+declare function getSmallPet(): Fish | Bird;
+
+let pet = getSmallPet();
+
+// 両方の型に共通する `layEggs` は呼び出せる
+pet.layEggs();
+
+// `swim` は Fish にしか存在しないため、コンパイルエラーになる
+// Property 'swim' does not exist on type 'Bird | Fish'.
+// pet.swim();
+```
+
+この問題を解決するためには、**型の絞り込み（Narrowing）** を行い、特定の型であることをコンパイラに伝える必要があります。
+
+### Discriminating Unions (判別可能なユニオン型)
+
+共通のプロパティ（通常はリテラル型）を判別材料として使用することで、ユニオン型を安全に扱うことができます。これは非常に強力なパターンです。
+
+```typescript
+type NetworkState =
+  | { state: "loading" }
+  | { state: "failed"; code: number }
+  | { state: "success"; response: { title: string } };
+
+function logger(state: NetworkState): void {
+  switch (state.state) {
+    case "loading":
+      console.log("Loading...");
+      break;
+    case "failed":
+      console.error(`Failed with error code ${state.code}`);
+      break;
+    case "success":
+      console.log(`Success: ${state.response.title}`);
+      break;
+  }
+}
+```
+`state.state` の値によって、TypeScriptは `state` の型を正確に推論し、それぞれのケースで固有のプロパティ（`code` や `response`）に安全にアクセスできるようになります。
+
+## インターセクション型 (Intersection Types)
+
+インターセクション型は、複数の型を一つに結合します。これにより、複数の型のすべてのメンバーを持つ単一の型を作成できます。アンパサンド (`&`) を使って型を結合します。
+
+```typescript
+interface Colorful {
+  color: string;
+}
+
+interface Circle {
+  radius: number;
+}
+
+type ColorfulCircle = Colorful & Circle;
+
+const myCircle: ColorfulCircle = {
+  color: "red",
+  radius: 10,
+};
+```
+
+この例では、`ColorfulCircle` 型は `Colorful` と `Circle` の両方のプロパティ（`color` と `radius`）を持つ必要があります。
+
+インターセクション型は、既存の型を拡張して、新しい一貫した機能を追加する際などに特に便利です。
+
+```typescript
+interface ErrorHandling {
+  success: boolean;
+  error?: { message: string };
+}
+
+interface ArtistsData {
+  artists: { name: string }[];
+}
+
+// ArtistsData と ErrorHandling を結合して、APIレスポンスの型を定義
+type ArtistsResponse = ArtistsData & ErrorHandling;
+
+const handleArtistsResponse = (response: ArtistsResponse) => {
+  if (response.error) {
+    console.error(response.error.message);
+    return;
+  }
+  console.log(response.artists);
+};
+```
+これにより、データ部分の型とエラーハンドリング部分の型を分離し、再利用可能な形で組み合わせることができます。

--- a/docs/typescript/01-basics/09-type-aliases-and-type-guards.md
+++ b/docs/typescript/01-basics/09-type-aliases-and-type-guards.md
@@ -1,0 +1,149 @@
+# 型エイリアスとタイプガード
+
+TypeScriptを効果的に使用するには、型を再利用可能にしたり、特定のコードブロック内で型を絞り込んだりするテクニックが不可欠です。ここでは、`type` キーワードによる型エイリアスと、型の安全性を高めるタイプガードについて説明します。
+
+## 型エイリアス (Type Aliases)
+
+型エイリアスは、既存の型に新しい名前を付ける機能です。これにより、複雑な型を再利用しやすくなり、コードの可読性が向上します。
+
+`type` キーワードを使って定義します。
+
+```typescript
+// プリミティブ型に別名を付ける
+type UserID = string;
+
+// オブジェクトリテラル型に別名を付ける
+type User = {
+  id: UserID;
+  name: string;
+  email?: string;
+};
+
+// ユニオン型に別名を付ける
+type Status = "success" | "loading" | "error";
+
+function processStatus(status: Status): void {
+  // ...
+}
+```
+
+### 型エイリアス vs インターフェース
+
+型エイリアスはインターフェース（`interface`）と似ていますが、いくつかの重要な違いがあります。
+
+| 機能 | インターフェース (`interface`) | 型エイリアス (`type`) |
+| :--- | :--- | :--- |
+| **拡張** | `extends` キーワードで拡張可能 | `&` (インターセクション型) を使って拡張可能 |
+| **宣言のマージ** | 同じ名前で複数宣言すると自動的にマージされる | 同じ名前で複数宣言するとエラーになる |
+| **表現できる型** | オブジェクトの形状の定義に特化 | プリミティブ、ユニオン、タプルなど、あらゆる型に別名を付けられる |
+
+**推奨される使い分け:**
+- オブジェクトの形状を定義する場合は、拡張やマージが可能な `interface` を使用するのが一般的です。
+- ユニオン型やタプル型など、`interface` で表現できない型に名前を付けたい場合は `type` を使用します。
+
+## タイプガード (Type Guards)
+
+タイプガードは、特定のスコープ内で変数の型をより具体的な型に絞り込む（narrowing）ための式です。これにより、ユニオン型などで扱われる変数のプロパティやメソッドに安全にアクセスできるようになります。
+
+### 1. `typeof` タイプガード
+
+`typeof` 演算子は、プリミティブ型（`string`, `number`, `boolean`, `symbol`, `bigint`, `undefined`, `object`, `function`）をチェックするために使用できます。
+
+```typescript
+function printValue(value: string | number) {
+  if (typeof value === "string") {
+    // このブロック内では value は string 型として扱われる
+    console.log(value.toUpperCase());
+  } else {
+    // このブロック内では value は number 型として扱われる
+    console.log(value.toFixed(2));
+  }
+}
+```
+
+### 2. `instanceof` タイプガード
+
+`instanceof` 演算子は、値が特定のクラスのインスタンスであるかどうかをチェックします。
+
+```typescript
+class Cat {
+  meow() {
+    console.log("Meow!");
+  }
+}
+class Dog {
+  bark() {
+    console.log("Woof!");
+  }
+}
+
+type Animal = Cat | Dog;
+
+function makeSound(animal: Animal) {
+  if (animal instanceof Cat) {
+    // animal は Cat 型
+    animal.meow();
+  } else {
+    // animal は Dog 型
+    animal.bark();
+  }
+}
+```
+
+### 3. `in` タイプガード
+
+`in` 演算子は、オブジェクトが特定のプロパティを持っているかどうかをチェックします。
+
+```typescript
+interface Car {
+  drive(): void;
+}
+interface Bicycle {
+  ride(): void;
+}
+
+type Vehicle = Car | Bicycle;
+
+function move(vehicle: Vehicle) {
+  if ("drive" in vehicle) {
+    // vehicle は Car 型
+    vehicle.drive();
+  } else {
+    // vehicle は Bicycle 型
+    vehicle.ride();
+  }
+}
+```
+
+### 4. ユーザー定義タイプガード (Type Predicates)
+
+より複雑なチェックのために、`is` キーワードを使った型述語（type predicate）を返す関数を定義できます。これは「ユーザー定義タイプガード」と呼ばれます。
+
+関数の戻り値の型を `argument is Type` の形式で注釈します。
+
+```typescript
+interface Fish {
+  swim(): void;
+}
+interface Bird {
+  fly(): void;
+}
+
+type Pet = Fish | Bird;
+
+// ユーザー定義タイプガード
+function isFish(pet: Pet): pet is Fish {
+  return (pet as Fish).swim !== undefined;
+}
+
+function feedPet(pet: Pet) {
+  if (isFish(pet)) {
+    // pet は Fish 型
+    console.log("Feeding fish...");
+  } else {
+    // pet は Bird 型
+    console.log("Feeding bird...");
+  }
+}
+```
+この `isFish` 関数が `true` を返した場合、TypeScriptコンパイラはそのスコープ内で `pet` 変数を `Fish` 型として扱います。これは、APIレスポンスの検証など、複雑なオブジェクトの型を判別する際に非常に役立ちます。

--- a/docs/typescript/01-basics/09-type-aliases-and-type-guards.md
+++ b/docs/typescript/01-basics/09-type-aliases-and-type-guards.md
@@ -133,7 +133,7 @@ type Pet = Fish | Bird;
 
 // ユーザー定義タイプガード
 function isFish(pet: Pet): pet is Fish {
-  return (pet as Fish).swim !== undefined;
+  return "swim" in pet;
 }
 
 function feedPet(pet: Pet) {

--- a/docs/typescript/01-basics/10-generics-basics.md
+++ b/docs/typescript/01-basics/10-generics-basics.md
@@ -1,0 +1,114 @@
+# ジェネリクスの基礎
+
+ジェネリクス（Generics）は、再利用可能で型安全なコンポーネント（関数、クラス、インターフェースなど）を作成するためのTypeScriptの重要な機能です。これにより、単一の型だけでなく、さまざまな型に対して機能するコンポーネントを定義できます。
+
+## ジェネリクスとは？
+
+ジェネリクスは、型を「変数」として扱うことを可能にします。コンポーネントを定義する時点では型を固定せず、利用する時点で具体的な型を指定します。
+
+### ジェネリクスの利点
+
+- **再利用性**: さまざまな型に対応できるため、同じロジックを何度も書く必要がなくなります。
+- **型安全性**: `any` を使うのとは異なり、コンポーネントを利用する際に指定された型情報を保持するため、コンパイル時の型チェックの恩恵を受けることができます。
+
+## はじめてのジェネリクス： `identity` 関数
+
+最もシンプルな例は、渡された引数をそのまま返す `identity` （恒等）関数です。
+
+`any` を使うと、どのような型が返ってくるかの情報が失われてしまいます。
+
+```typescript
+function identity(arg: any): any {
+  return arg;
+}
+
+let output = identity("myString"); // output の型は any になってしまう
+```
+
+そこでジェネリクスを使います。型引数 `<Type>` を導入し、引数と戻り値の型を関連付けます。
+
+```typescript
+function identity<Type>(arg: Type): Type {
+  return arg;
+}
+
+// 型を明示的に指定する場合
+let output1 = identity<string>("myString"); // output1 は string 型
+
+// 型推論に任せる場合（より一般的）
+let output2 = identity("myString"); // output2 は string 型
+```
+`Type` は型引数（type parameter）と呼ばれ、この関数が呼び出されるときに実際の型（この場合は `string`）に置き換えられます。
+
+## ジェネリックな型
+
+ジェネリクスは関数だけでなく、インターフェースやクラスにも適用できます。
+
+### ジェネリックインターフェース
+
+```typescript
+interface GenericBox<Type> {
+  value: Type;
+}
+
+let stringBox: GenericBox<string> = { value: "hello" };
+let numberBox: GenericBox<number> = { value: 123 };
+```
+
+### ジェネリッククラス
+
+```typescript
+class GenericNumber<NumType> {
+  zeroValue: NumType;
+  add: (x: NumType, y: NumType) => NumType;
+}
+
+let myGenericNumber = new GenericNumber<number>();
+myGenericNumber.zeroValue = 0;
+myGenericNumber.add = function (x, y) {
+  return x + y;
+};
+
+let myGenericString = new GenericNumber<string>();
+myGenericString.zeroValue = "";
+myGenericString.add = function (x, y) {
+  return x + y;
+};
+```
+
+## ジェネリック制約 (Generic Constraints)
+
+ジェネリクスを使用する際、型引数が特定のプロパティやメソッドを持つことを保証したい場合があります。その場合は `extends` キーワードを使って制約を追加します。
+
+例えば、引数の `length` プロパティにアクセスしたい関数を考えます。
+
+```typescript
+// このままでは Type が .length を持つか不明なためエラーになる
+// function loggingIdentity<Type>(arg: Type): Type {
+//   console.log(arg.length); // Error: Property 'length' does not exist on type 'Type'.
+//   return arg;
+// }
+```
+
+`length` プロパティを持つ型に制約します。
+
+```typescript
+interface Lengthwise {
+  length: number;
+}
+
+function loggingIdentity<Type extends Lengthwise>(arg: Type): Type {
+  console.log(arg.length); // エラーにならない
+  return arg;
+}
+
+// OK
+loggingIdentity("hello"); // string は length プロパティを持つ
+loggingIdentity([1, 2, 3]); // array は length プロパティを持つ
+loggingIdentity({ length: 10, value: 3 }); // オブジェクトも length プロパティを持つ
+
+// Error
+// Argument of type 'number' is not assignable to parameter of type 'Lengthwise'.
+// loggingIdentity(3);
+```
+`Type extends Lengthwise` とすることで、この関数に渡せる型は `Lengthwise` インターフェースの要件（`length: number` を持つこと）を満たすものに限定され、関数内で安全に `arg.length` にアクセスできるようになります。

--- a/docs/typescript/02-advanced/01-advanced-generics.md
+++ b/docs/typescript/02-advanced/01-advanced-generics.md
@@ -1,0 +1,124 @@
+# 高度なジェネリクス
+
+ジェネリクスの基本的な使い方をマスターしたら、次はTypeScriptの型システムをさらに活用するための高度なテクニックを見ていきましょう。これらは、型レベルでのプログラミング（型操作）の扉を開く強力なツールです。
+
+## `keyof` とルックアップ型
+
+`keyof` 演算子は、オブジェクトのキー（プロパティ名）を文字列リテラルユニオンとして取得します。
+
+```typescript
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+type UserKeys = keyof User; // "id" | "name" | "email"
+```
+
+そして、ルックアップ型 (`T[K]`) を使うと、オブジェクト `T` のプロパティ `K` の型を取得できます。
+
+```typescript
+type UserEmailType = User["email"]; // string
+```
+
+これらをジェネリクスと組み合わせることで、非常に強力な型安全性を実現できます。
+
+### 例：プロパティを取得する関数
+
+オブジェクトとそのプロパティ名を引数に取り、そのプロパティの値を返す関数を考えます。
+
+```typescript
+function getProperty<T, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+
+const user: User = {
+  id: 1,
+  name: "John Doe",
+  email: "john.doe@example.com",
+};
+
+const userName = getProperty(user, "name"); // string
+const userEmail = getProperty(user, "email"); // string
+
+// Error: Argument of type '"age"' is not assignable to parameter of type 'keyof User'.
+// const userAge = getProperty(user, "age");
+```
+`K extends keyof T` というジェネリック制約により、`key` 引数には `obj` に実際に存在するプロパティ名しか渡せないようにコンパイラが保証してくれます。戻り値の型も `T[K]` となるため、取得した値の型も正確に推論されます。
+
+## マップ型 (Mapped Types)
+
+マップ型は、既存の型を基にして新しい型を生成する機能です。既存の型の各プロパティをループして、新しい型に変換します。`in keyof` という構文を使用します。
+
+### `Partial<T>` の実装
+
+例えば、すべてのプロパティをオプショナルにする `Partial<T>` というユーティリティ型は、マップ型で実装されています。
+
+```typescript
+type Partial<T> = {
+  [P in keyof T]?: T[P];
+};
+
+interface Todo {
+  title: string;
+  completed: boolean;
+}
+
+// { title?: string; completed?: boolean; } と同じ型になる
+type PartialTodo = Partial<Todo>;
+```
+
+### `Readonly<T>` の実装
+
+同様に、すべてのプロパティを読み取り専用にする `Readonly<T>` もマップ型で実装できます。
+
+```typescript
+type Readonly<T> = {
+  readonly [P in keyof T]: T[P];
+};
+
+// { readonly title: string; readonly completed: boolean; } と同じ型になる
+type ReadonlyTodo = Readonly<Todo>;
+```
+マップ型を使うことで、既存の型から派生した型を DRY (Don't Repeat Yourself) の原則に従って効率的に作成できます。
+
+## 条件型 (Conditional Types)
+
+条件型は、型レベルの三項演算子のようなもので、型`T`が型`U`に代入可能かどうかに基づいて、2つの型のうちの1つを選択します。
+
+構文は `T extends U ? X : Y` です。
+
+```typescript
+interface IdLabel {
+  id: number;
+}
+interface NameLabel {
+  name: string;
+}
+
+// T が number を継承していれば IdLabel、そうでなければ NameLabel を返す
+type LabelType<T> = T extends number ? IdLabel : NameLabel;
+
+let idLabel: LabelType<number>;   // IdLabel
+let nameLabel: LabelType<string>; // NameLabel
+```
+
+### `infer` キーワード
+
+条件型の中でも特に強力なのが `infer` キーワードです。これにより、条件式の中で新しい型変数を「推論」し、その後の型定義で使用できます。
+
+関数の戻り値の型を抽出する `ReturnType<T>` は、この `infer` を使って実装されています。
+
+```typescript
+type ReturnType<T> = T extends (...args: any[]) => infer R ? R : any;
+
+type MyFunc = () => string;
+
+// string 型が抽出される
+type MyFuncReturnType = ReturnType<MyFunc>;
+```
+
+この例では、`T` が関数型にマッチする場合、その戻り値の型を新しい型変数 `R` として推論（`infer R`）し、結果として `R` を返しています。
+
+これらの高度なジェネリクスを組み合わせることで、非常に柔軟で型安全なユーティリティやライブラリを構築することが可能になります。

--- a/docs/typescript/02-advanced/02-conditional-types.md
+++ b/docs/typescript/02-advanced/02-conditional-types.md
@@ -1,0 +1,89 @@
+# 条件型 (Conditional Types)
+
+条件型は、TypeScriptの型システムにおける強力なツールの一つで、型レベルで条件分岐を表現することができます。これにより、入力された型に応じて出力される型を動的に変更することが可能になります。
+
+## 条件型の基本
+
+条件型は、JavaScriptの三項演算子 (`condition ? trueValue : falseValue`) と非常によく似た構文を持ちます。
+
+```typescript
+T extends U ? X : Y
+```
+
+この構文は以下のように解釈されます。
+- 「もし型 `T` が型 `U` に代入可能（`extends`）であれば、型 `X` を選択する。」
+- 「そうでなければ、型 `Y` を選択する。」
+
+### 簡単な例
+
+```typescript
+type IsString<T> = T extends string ? true : false;
+
+type A = IsString<string>; // true
+type B = IsString<number>; // false
+```
+この例では、`IsString<T>` は型 `T` が `string` 型に代入可能かどうかをチェックし、その結果に応じて `true` 型または `false` 型を返します。
+
+## 分配条件型 (Distributive Conditional Types)
+
+条件型のチェック対象 `T` が「裸の型パラメータ」（他の型でラップされていないジェネリックな型）であり、かつユニオン型である場合、その条件はユニオンの各メンバーに対して個別に適用（分配）されます。
+
+```typescript
+type ToArray<T> = T extends any ? T[] : never;
+
+// "string | number" の各メンバーに適用される
+// (string extends any ? string[] : never) | (number extends any ? number[] : never)
+// 結果: string[] | number[]
+type StrOrNumArray = ToArray<string | number>;
+```
+
+この分配的な性質を利用して、ユニオン型から特定の型を除外するような操作が可能です。TypeScriptの標準ユーティリティ型である `Exclude<T, U>` はこの仕組みを利用しています。
+
+```typescript
+// T から U に代入可能な型を取り除く
+type Exclude<T, U> = T extends U ? never : T;
+
+type T0 = Exclude<"a" | "b" | "c", "a">; // "b" | "c"
+type T1 = Exclude<"a" | "b" | "c", "a" | "b">; // "c"
+type T2 = Exclude<string | number | (() => void), Function>; // string | number
+```
+`never` 型はユニオン型においては無視されるため、条件が真になった型が最終的なユニオンから取り除かれます。
+
+## `infer` キーワードによる型推論
+
+条件型の中で最も強力な機能の一つが `infer` キーワードです。`infer` を使うと、`extends` 節の内部で型を「推論」して新しい型変数としてキャプチャし、条件が真の場合のブランチでその型を利用できます。
+
+### `ReturnType<T>` の実装
+
+関数の戻り値の型を抽出する標準ユーティリティ型 `ReturnType<T>` は、`infer` の代表的な使用例です。
+
+```typescript
+type ReturnType<T> = T extends (...args: any[]) => infer R ? R : any;
+```
+
+この定義は以下のように動作します。
+1. `T` が `(...args: any[]) => any` という関数シグネチャにマッチするかどうかをチェックします。
+2. マッチする場合、その関数の戻り値の型を新しい型変数 `R` として**推論（infer）**します。
+3. 結果として、推論された型 `R` を返します。
+4. マッチしない場合は `any` 型を返します。
+
+```typescript
+type MyFunc = (name: string) => { id: number; name: string };
+
+// { id: number; name: string } 型が抽出される
+type User = ReturnType<MyFunc>;
+```
+
+### 配列の要素の型を抽出する
+
+`infer` を使えば、配列の要素の型を抽出するようなユーティリティ型も簡単に作成できます。
+
+```typescript
+type Flatten<T> = T extends (infer Item)[] ? Item : T;
+
+type Str = Flatten<string[]>; // string
+type Num = Flatten<number[]>; // number
+type Whatever = Flatten<boolean>; // boolean (配列ではないので T 自身が返る)
+```
+
+条件型と `infer` を組み合わせることで、TypeScriptの型システムを最大限に活用し、非常に高度で柔軟な型操作を実現できます。

--- a/docs/typescript/index.md
+++ b/docs/typescript/index.md
@@ -9,13 +9,13 @@
 - [x] [オブジェクト型とインターフェース](./01-basics/05-object-types-and-interfaces.md)
 - [x] [配列とタプル型](./01-basics/06-arrays-and-tuples.md)
 - [x] [関数型とオーバーロード](./01-basics/07-function-types-and-overloads.md)
-- [ ] [ユニオン型とインターセクション型]
-- [ ] [型エイリアスとタイプガード]
-- [ ] [ジェネリクスの基礎]
+- [x] [ユニオン型とインターセクション型](./01-basics/08-union-and-intersection-types.md)
+- [x] [型エイリアスとタイプガード](./01-basics/09-type-aliases-and-type-guards.md)
+- [x] [ジェネリクスの基礎](./01-basics/10-generics-basics.md)
 ## 2. TypeScript発展
 
-- [ ] [高度なジェネリクス]
-- [ ] [条件型（Conditional Types）]
+- [x] [高度なジェネリクス](./02-advanced/01-advanced-generics.md)
+- [x] [条件型（Conditional Types）](./02-advanced/02-conditional-types.md)
 - [ ] [マップ型（Mapped Types）]
 - [ ] [テンプレートリテラル型]
 - [ ] [型レベルプログラミング]


### PR DESCRIPTION
このコミットは、TypeScriptのドキュメント用に5つの新しい記事を作成し、それぞれのトピックに関する内容を記述します。

以下のファイルが作成・執筆されました。
- `docs/typescript/01-basics/08-union-and-intersection-types.md`
- `docs/typescript/01-basics/09-type-aliases-and-type-guards.md`
- `docs/typescript/01-basics/10-generics-basics.md`
- `docs/typescript/02-advanced/01-advanced-generics.md`
- `docs/typescript/02-advanced/02-conditional-types.md`

さらに、`docs/typescript/index.md` が更新され、これらの新しい記事へのリンクと完了マークが追加されました。