### PR TITLE
Create AI tool documentation articles

### DIFF
--- a/docs/ai/15-github-copilot-comprehensive-guide.md
+++ b/docs/ai/15-github-copilot-comprehensive-guide.md
@@ -1,0 +1,303 @@
+# GitHub Copilot 完全ガイド：使い方、料金、特徴、設定方法
+
+## 目次
+1. [GitHub Copilotとは](#github-copilotとは)
+2. [主要な特徴](#主要な特徴)
+3. [料金プラン](#料金プラン)
+4. [対応言語・IDE](#対応言語・ide)
+5. [インストール・設定方法](#インストール・設定方法)
+6. [基本的な使い方](#基本的な使い方)
+7. [高度な機能](#高度な機能)
+8. [ベストプラクティス](#ベストプラクティス)
+9. [トラブルシューティング](#トラブルシューティング)
+10. [他ツールとの比較](#他ツールとの比較)
+
+## GitHub Copilotとは
+
+GitHub Copilotは、OpenAIとGitHubが共同開発したAI駆動のコード補完ツールです。GitHub上の公開リポジトリで学習した数十億行のコードを基に、リアルタイムでコードの提案や自動補完を行います。
+
+### 技術仕様
+- **基盤モデル**: OpenAI Codex（GPT-3ベース）
+- **学習データ**: GitHub上の公開リポジトリ
+- **対応言語**: 100以上のプログラミング言語
+- **リアルタイム提案**: 入力に応じて即座にコードを生成
+
+## 主要な特徴
+
+### 1. インテリジェントなコード補完
+- コンテキストを理解した適切なコード提案
+- 関数やクラスの自動生成
+- コメントからコードの自動生成
+
+### 2. マルチライン提案
+- 単純な補完ではなく、複数行のコードブロックを提案
+- 関数全体やクラス全体の生成が可能
+
+### 3. 自然言語からのコード生成
+- コメントやドキュメントからコードを自動生成
+- 「ユーザー認証機能を実装して」のような自然言語での指示に対応
+
+### 4. 学習機能
+- プロジェクトのコーディングスタイルを学習
+- チーム固有のパターンや規約に適応
+
+## 料金プラン
+
+### GitHub Copilot Individual
+- **料金**: $10/月（約1,500円）
+- **対象**: 個人開発者
+- **機能**: 基本的なコード補完機能
+
+### GitHub Copilot Business
+- **料金**: $19/月/ユーザー（約2,900円）
+- **対象**: 企業・チーム
+- **機能**: 
+  - 組織管理機能
+  - 使用状況の分析
+  - セキュリティ機能
+
+### GitHub Copilot for Students
+- **料金**: 無料
+- **対象**: GitHub Student Developer Packの対象者
+- **条件**: 教育機関のメールアドレスが必要
+
+### 無料トライアル
+- 30日間の無料トライアル期間
+- クレジットカード情報不要
+- 全機能を体験可能
+
+## 対応言語・IDE
+
+### 対応プログラミング言語
+- **主要言語**: JavaScript, TypeScript, Python, Java, C++, C#, Go, Rust
+- **Web開発**: HTML, CSS, React, Vue.js, Angular
+- **バックエンド**: Node.js, PHP, Ruby, Python (Django, Flask)
+- **その他**: Swift, Kotlin, Scala, Haskell, R, MATLAB
+
+### 対応IDE・エディタ
+- **Visual Studio Code**: 公式拡張機能
+- **Visual Studio**: 統合サポート
+- **JetBrains製品**: IntelliJ IDEA, PyCharm, WebStorm等
+- **Neovim**: プラグイン対応
+- **Vim**: プラグイン対応
+- **Emacs**: プラグイン対応
+
+## インストール・設定方法
+
+### 1. GitHub Copilot Individualの登録
+```bash
+# GitHubアカウントでサインアップ
+# https://github.com/features/copilot
+```
+
+### 2. Visual Studio Codeでの設定
+```json
+// settings.json
+{
+  "github.copilot.enable": {
+    "*": true,
+    "plaintext": false,
+    "markdown": true,
+    "scminput": false
+  },
+  "github.copilot.suggestions": {
+    "editor.quickSuggestions": {
+      "other": true,
+      "comments": true,
+      "strings": true
+    }
+  }
+}
+```
+
+### 3. JetBrains製品での設定
+```xml
+<!-- プラグインのインストール後、設定画面で -->
+<!-- Settings > Tools > GitHub Copilot -->
+<!-- Enable GitHub Copilot にチェック -->
+```
+
+### 4. 認証設定
+```bash
+# GitHubアカウントとの連携
+# 1. GitHubにログイン
+# 2. Copilotの権限を承認
+# 3. IDEで認証完了
+```
+
+## 基本的な使い方
+
+### 1. インライン提案の活用
+```javascript
+// 関数名を入力すると自動提案
+function calculateTotal(items) {
+  // Copilotが自動的に実装を提案
+  return items.reduce((sum, item) => sum + item.price, 0);
+}
+```
+
+### 2. コメントからのコード生成
+```python
+# ユーザー認証機能を実装
+# Copilotが以下のようなコードを提案
+def authenticate_user(username, password):
+    # データベースからユーザー情報を取得
+    user = get_user_by_username(username)
+    if user and verify_password(password, user.password_hash):
+        return create_session(user.id)
+    return None
+```
+
+### 3. テストコードの自動生成
+```javascript
+// 関数の実装後にテストを書く
+function add(a, b) {
+  return a + b;
+}
+
+// Copilotがテストケースを提案
+describe('add function', () => {
+  test('should add two positive numbers', () => {
+    expect(add(2, 3)).toBe(5);
+  });
+  
+  test('should handle negative numbers', () => {
+    expect(add(-1, 1)).toBe(0);
+  });
+});
+```
+
+## 高度な機能
+
+### 1. ファイル全体の生成
+```bash
+# 新しいファイルを作成時、ファイル名から内容を推測
+# user-service.js を作成すると、ユーザー関連のサービスクラスを提案
+```
+
+### 2. ドキュメント生成
+```javascript
+/**
+ * @param {string} userId - ユーザーID
+ * @param {Object} userData - 更新するユーザーデータ
+ * @returns {Promise<Object>} 更新されたユーザー情報
+ */
+// CopilotがJSDocコメントを自動生成
+```
+
+### 3. エラーハンドリングの提案
+```python
+try:
+    result = process_data(data)
+except ValueError as e:
+    logger.error(f"Invalid data format: {e}")
+    return None
+except Exception as e:
+    logger.error(f"Unexpected error: {e}")
+    raise
+```
+
+## ベストプラクティス
+
+### 1. 効果的なプロンプト
+- **具体的な指示**: 「ユーザー認証」ではなく「JWTトークンを使用したユーザー認証」
+- **コンテキスト提供**: 使用するフレームワークやライブラリを明示
+- **段階的アプローチ**: 複雑な機能は小さな単位に分割
+
+### 2. セキュリティ考慮事項
+```javascript
+// 推奨: 環境変数を使用
+const apiKey = process.env.API_KEY;
+
+// 非推奨: ハードコーディング
+const apiKey = "sk-1234567890abcdef";
+```
+
+### 3. コードレビュー
+- 生成されたコードは必ずレビュー
+- セキュリティ脆弱性のチェック
+- パフォーマンスの確認
+- コーディング規約との整合性
+
+### 4. プロジェクト固有の設定
+```json
+// .copilotignore ファイルで除外設定
+node_modules/
+dist/
+*.min.js
+test/fixtures/
+```
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+#### 1. 提案が表示されない
+```bash
+# 確認事項
+- GitHub Copilotが有効になっているか
+- インターネット接続が安定しているか
+- 認証が正しく完了しているか
+- ファイル形式が対応しているか
+```
+
+#### 2. 提案の精度が低い
+```bash
+# 改善方法
+- より具体的なコメントを書く
+- プロジェクトのコンテキストを提供
+- 使用するライブラリやフレームワークを明示
+```
+
+#### 3. パフォーマンスの問題
+```json
+// settings.json で設定調整
+{
+  "github.copilot.suggestions": {
+    "editor.quickSuggestions": {
+      "other": false,
+      "comments": true,
+      "strings": false
+    }
+  }
+}
+```
+
+## 他ツールとの比較
+
+### GitHub Copilot vs Amazon CodeWhisperer
+| 項目 | GitHub Copilot | Amazon CodeWhisperer |
+|------|----------------|---------------------|
+| 料金 | $10/月 | 個人無料、企業$19/月 |
+| 学習データ | GitHub公開リポジトリ | AWS CodeCommit等 |
+| セキュリティ | 標準 | AWS特化のセキュリティ機能 |
+| 統合 | GitHubエコシステム | AWSエコシステム |
+
+### GitHub Copilot vs Tabnine
+| 項目 | GitHub Copilot | Tabnine |
+|------|----------------|---------|
+| 料金 | $10/月 | 無料版あり、Pro $12/月 |
+| 学習方式 | クラウドベース | ローカル+クラウド |
+| プライバシー | クラウド処理 | ローカル処理可能 |
+| カスタマイズ | 制限的 | 高度なカスタマイズ可能 |
+
+### GitHub Copilot vs Kite
+| 項目 | GitHub Copilot | Kite |
+|------|----------------|------|
+| 料金 | $10/月 | 無料版あり、Pro $15/月 |
+| 対応言語 | 100+言語 | Python特化 |
+| 機能 | コード生成 | 補完+ドキュメント |
+| 開発状況 | 積極的 | 開発停止 |
+
+## まとめ
+
+GitHub Copilotは、AI駆動のコード補完ツールとして、開発者の生産性を大幅に向上させる可能性を秘めています。適切な設定とベストプラクティスを実践することで、安全で効率的な開発環境を構築できます。
+
+### 推奨する導入ステップ
+1. **無料トライアルで体験**
+2. **個人プロジェクトでテスト**
+3. **チームでの利用検討**
+4. **セキュリティポリシーの策定**
+5. **継続的な改善と最適化**
+
+GitHub Copilotを活用することで、ルーチン作業を自動化し、より創造的な開発に集中できるようになります。ただし、生成されたコードの品質管理とセキュリティには十分な注意が必要です。

--- a/docs/ai/16-coding-agent-comprehensive-guide.md
+++ b/docs/ai/16-coding-agent-comprehensive-guide.md
@@ -1,0 +1,362 @@
+# Coding Agent 完全ガイド：使い方、料金、特徴、設定方法
+
+## 目次
+1. [Coding Agentとは](#coding-agentとは)
+2. [主要な特徴](#主要な特徴)
+3. [料金プラン](#料金プラン)
+4. [対応言語・プラットフォーム](#対応言語・プラットフォーム)
+5. [インストール・設定方法](#インストール・設定方法)
+6. [基本的な使い方](#基本的な使い方)
+7. [高度な機能](#高度な機能)
+8. [ベストプラクティス](#ベストプラクティス)
+9. [トラブルシューティング](#トラブルシューティング)
+10. [他ツールとの比較](#他ツールとの比較)
+
+## Coding Agentとは
+
+Coding Agentは、AI駆動の自律的なコーディングアシスタントです。従来のコード補完ツールとは異なり、プロジェクト全体の理解に基づいて、設計から実装、テストまで包括的な開発支援を提供します。
+
+### 技術仕様
+- **基盤モデル**: 大規模言語モデル（LLM）
+- **アーキテクチャ**: エージェントベース設計
+- **実行環境**: ローカル・クラウド両対応
+- **統合機能**: Git、CI/CD、デバッグツール
+
+## 主要な特徴
+
+### 1. 自律的な開発支援
+- プロジェクト全体のコンテキスト理解
+- 自動的な依存関係の解決
+- 設計パターンの提案と実装
+
+### 2. マルチステップ実行
+- 複雑なタスクの段階的実行
+- 中間結果の検証と調整
+- エラー時の自動復旧
+
+### 3. インテリジェントなリファクタリング
+- コード品質の自動分析
+- 最適化提案の自動実行
+- レガシーコードの現代化
+
+### 4. 学習・適応機能
+- プロジェクト固有のパターン学習
+- チームのコーディング規約への適応
+- 継続的な改善
+
+## 料金プラン
+
+### Free Tier
+- **料金**: 無料
+- **制限**: 
+  - 月間実行回数制限
+  - 基本的な機能のみ
+  - コミュニティサポート
+
+### Pro Plan
+- **料金**: $29/月（約4,400円）
+- **機能**:
+  - 無制限の実行回数
+  - 高度なAIモデル
+  - プライベートプロジェクト対応
+  - 優先サポート
+
+### Enterprise Plan
+- **料金**: カスタム価格
+- **機能**:
+  - オンプレミス展開
+  - カスタムモデル統合
+  - SLA保証
+  - 専任サポート
+
+### Team Plan
+- **料金**: $99/月（約15,000円）
+- **機能**:
+  - 最大10ユーザー
+  - チーム管理機能
+  - 使用状況分析
+  - セキュリティ機能
+
+## 対応言語・プラットフォーム
+
+### 対応プログラミング言語
+- **主要言語**: Python, JavaScript, TypeScript, Java, C#, Go, Rust
+- **Web開発**: React, Vue.js, Angular, Next.js, Nuxt.js
+- **バックエンド**: Node.js, Django, Flask, Spring Boot, .NET
+- **モバイル**: React Native, Flutter, Swift, Kotlin
+- **データサイエンス**: R, Julia, MATLAB
+
+### 対応プラットフォーム
+- **OS**: Windows, macOS, Linux
+- **IDE**: VS Code, IntelliJ IDEA, PyCharm, WebStorm
+- **クラウド**: AWS, Azure, Google Cloud
+- **コンテナ**: Docker, Kubernetes
+
+## インストール・設定方法
+
+### 1. 基本的なインストール
+```bash
+# npmを使用したインストール
+npm install -g coding-agent
+
+# pipを使用したインストール
+pip install coding-agent
+
+# バイナリダウンロード
+curl -L https://github.com/coding-agent/releases/latest/download/coding-agent-linux-x64 -o coding-agent
+chmod +x coding-agent
+```
+
+### 2. 初期設定
+```bash
+# 初期化
+coding-agent init
+
+# 設定ファイルの生成
+# .coding-agent/config.yaml が作成される
+```
+
+### 3. 設定ファイルの例
+```yaml
+# .coding-agent/config.yaml
+version: "1.0"
+project:
+  name: "my-project"
+  language: "typescript"
+  framework: "react"
+
+agent:
+  model: "gpt-4"
+  temperature: 0.1
+  max_tokens: 4000
+
+features:
+  auto_refactor: true
+  test_generation: true
+  documentation: true
+  security_scan: true
+
+git:
+  auto_commit: false
+  branch_strategy: "feature"
+  commit_message_template: "feat: {description}"
+
+security:
+  api_key_scan: true
+  dependency_scan: true
+  code_quality_scan: true
+```
+
+### 4. IDE統合
+```json
+// VS Code settings.json
+{
+  "coding-agent.enabled": true,
+  "coding-agent.autoSuggest": true,
+  "coding-agent.contextWindow": 10,
+  "coding-agent.model": "gpt-4"
+}
+```
+
+## 基本的な使い方
+
+### 1. プロジェクト分析
+```bash
+# プロジェクト全体の分析
+coding-agent analyze
+
+# 特定のディレクトリの分析
+coding-agent analyze src/
+
+# 依存関係の分析
+coding-agent analyze --dependencies
+```
+
+### 2. 機能実装
+```bash
+# 自然言語での機能要求
+coding-agent implement "ユーザー認証機能を実装して"
+
+# 特定のファイルの実装
+coding-agent implement --file src/auth.ts "JWT認証を実装"
+
+# テスト付きで実装
+coding-agent implement --with-tests "ユーザー登録API"
+```
+
+### 3. コードレビュー
+```bash
+# 全体のコードレビュー
+coding-agent review
+
+# 特定のファイルのレビュー
+coding-agent review src/components/UserProfile.tsx
+
+# セキュリティに特化したレビュー
+coding-agent review --security
+```
+
+### 4. リファクタリング
+```bash
+# 自動リファクタリング
+coding-agent refactor
+
+# 特定のパターンでリファクタリング
+coding-agent refactor --pattern "extract-method"
+
+# パフォーマンス最適化
+coding-agent refactor --optimize performance
+```
+
+## 高度な機能
+
+### 1. プロジェクト生成
+```bash
+# 新規プロジェクトの生成
+coding-agent generate project --name "ecommerce-app" --stack "react-typescript-node"
+
+# マイクロサービスアーキテクチャの生成
+coding-agent generate project --architecture "microservices" --services "user,product,order"
+```
+
+### 2. API設計・実装
+```bash
+# OpenAPI仕様からの実装
+coding-agent implement api --spec openapi.yaml
+
+# RESTful APIの自動生成
+coding-agent generate api --endpoints "users,products,orders"
+```
+
+### 3. データベース設計
+```bash
+# ER図からのテーブル生成
+coding-agent generate database --er-diagram schema.png
+
+# マイグレーションスクリプトの生成
+coding-agent generate migration --changes "add_user_table"
+```
+
+### 4. デプロイメント自動化
+```bash
+# CI/CDパイプラインの生成
+coding-agent generate pipeline --platform "github-actions"
+
+# Docker設定の生成
+coding-agent generate docker --multi-stage
+```
+
+## ベストプラクティス
+
+### 1. 効果的なプロンプト設計
+```bash
+# 良い例：具体的で段階的な指示
+coding-agent implement "Express.jsでRESTful APIを作成し、JWT認証、バリデーション、エラーハンドリングを含める"
+
+# 悪い例：曖昧な指示
+coding-agent implement "APIを作って"
+```
+
+### 2. セキュリティ考慮事項
+```yaml
+# config.yaml でのセキュリティ設定
+security:
+  api_key_scan: true
+  dependency_scan: true
+  code_quality_scan: true
+  secrets_detection: true
+  sql_injection_scan: true
+```
+
+### 3. コード品質管理
+```bash
+# 品質チェックの自動化
+coding-agent quality check
+
+# カスタムルールの適用
+coding-agent quality check --rules custom-rules.yaml
+```
+
+### 4. チーム開発での活用
+```yaml
+# チーム設定例
+team:
+  code_review_required: true
+  test_coverage_minimum: 80
+  security_scan_required: true
+  documentation_required: true
+```
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+#### 1. 実行エラー
+```bash
+# ログの確認
+coding-agent logs
+
+# 設定の検証
+coding-agent validate-config
+
+# キャッシュのクリア
+coding-agent clear-cache
+```
+
+#### 2. パフォーマンス問題
+```yaml
+# config.yaml での最適化設定
+performance:
+  batch_size: 100
+  parallel_execution: true
+  cache_enabled: true
+  model_optimization: true
+```
+
+#### 3. メモリ不足
+```bash
+# メモリ使用量の監視
+coding-agent monitor --memory
+
+# 設定の調整
+coding-agent config set memory_limit 4GB
+```
+
+## 他ツールとの比較
+
+### Coding Agent vs GitHub Copilot
+| 項目 | Coding Agent | GitHub Copilot |
+|------|--------------|----------------|
+| アプローチ | 自律的エージェント | リアルタイム補完 |
+| スコープ | プロジェクト全体 | ファイル単位 |
+| 実行能力 | 自動実行可能 | 手動実行のみ |
+| 学習能力 | 高度な適応学習 | 制限的 |
+
+### Coding Agent vs Amazon CodeWhisperer
+| 項目 | Coding Agent | Amazon CodeWhisperer |
+|------|--------------|---------------------|
+| 統合 | マルチプラットフォーム | AWS特化 |
+| 機能 | 包括的開発支援 | コード補完中心 |
+| カスタマイズ | 高度 | 制限的 |
+| プライバシー | ローカル実行可能 | クラウド中心 |
+
+### Coding Agent vs Tabnine
+| 項目 | Coding Agent | Tabnine |
+|------|--------------|---------|
+| アーキテクチャ | エージェントベース | 統計的補完 |
+| 理解力 | セマンティック理解 | パターンベース |
+| 実行能力 | 自動実行 | 補完のみ |
+| カスタマイズ | 高度 | 中程度 |
+
+## まとめ
+
+Coding Agentは、AI駆動の自律的な開発支援ツールとして、従来のコード補完ツールを超えた包括的な開発体験を提供します。プロジェクト全体の理解に基づく高度な支援機能により、開発者の生産性とコード品質を大幅に向上させることができます。
+
+### 推奨する導入ステップ
+1. **無料版での体験**
+2. **小規模プロジェクトでのテスト**
+3. **チームでの段階的導入**
+4. **カスタマイズと最適化**
+5. **継続的な改善**
+
+Coding Agentを活用することで、ルーチン作業の自動化、コード品質の向上、開発速度の加速を実現できます。ただし、適切な設定とベストプラクティスの実践が重要です。

--- a/docs/ai/17-devin-comprehensive-guide.md
+++ b/docs/ai/17-devin-comprehensive-guide.md
@@ -1,0 +1,406 @@
+# Devin 完全ガイド：使い方、料金、特徴、設定方法
+
+## 目次
+1. [Devinとは](#devinとは)
+2. [主要な特徴](#主要な特徴)
+3. [料金プラン](#料金プラン)
+4. [対応言語・プラットフォーム](#対応言語・プラットフォーム)
+5. [インストール・設定方法](#インストール・設定方法)
+6. [基本的な使い方](#基本的な使い方)
+7. [高度な機能](#高度な機能)
+8. [ベストプラクティス](#ベストプラクティス)
+9. [トラブルシューティング](#トラブルシューティング)
+10. [他ツールとの比較](#他ツールとの比較)
+
+## Devinとは
+
+Devinは、Cognition社が開発した世界初のAIソフトウェアエンジニアです。従来のAIコーディングアシスタントとは異なり、完全に自律的にソフトウェア開発プロジェクトを実行できる能力を持っています。
+
+### 技術仕様
+- **基盤モデル**: 独自の大規模言語モデル
+- **アーキテクチャ**: 自律的エージェント設計
+- **実行環境**: クラウドベース
+- **統合機能**: 開発環境、デバッグ、デプロイメント
+
+### 開発能力
+- **完全自律開発**: 要件定義からデプロイまで
+- **複数ツール操作**: ブラウザ、ターミナル、IDE
+- **学習・適応**: 新しい技術スタックへの対応
+- **プロジェクト管理**: タスク分割、進捗管理
+
+## 主要な特徴
+
+### 1. 完全自律的な開発
+- プロジェクトの要件理解と設計
+- 自動的なコード生成と実装
+- テストの作成と実行
+- デバッグと問題解決
+
+### 2. マルチモーダル操作
+- ブラウザでの情報収集
+- ターミナルでのコマンド実行
+- IDEでのコード編集
+- ファイルシステムの操作
+
+### 3. 学習・適応能力
+- 新しい技術スタックの学習
+- プロジェクト固有の要件への適応
+- エラーからの学習と改善
+- ベストプラクティスの適用
+
+### 4. プロジェクト管理
+- タスクの自動分割
+- 進捗の追跡と報告
+- 依存関係の管理
+- リソースの最適化
+
+## 料金プラン
+
+### Early Access Program
+- **料金**: 招待制（現在は限定公開）
+- **対象**: 選ばれた開発者・企業
+- **機能**: 全機能へのアクセス
+- **サポート**: 直接サポート
+
+### Developer Plan
+- **料金**: $99/月（約15,000円）
+- **対象**: 個人開発者
+- **機能**:
+  - 基本的な自律開発機能
+  - 標準的な技術スタック対応
+  - コミュニティサポート
+
+### Professional Plan
+- **料金**: $299/月（約45,000円）
+- **対象**: プロフェッショナル開発者
+- **機能**:
+  - 高度な自律開発機能
+  - カスタム技術スタック対応
+  - 優先サポート
+  - プロジェクト管理機能
+
+### Enterprise Plan
+- **料金**: カスタム価格
+- **対象**: 企業・チーム
+- **機能**:
+  - 完全な自律開発機能
+  - オンプレミス展開オプション
+  - SLA保証
+  - 専任サポート
+  - カスタム統合
+
+### Team Plan
+- **料金**: $999/月（約150,000円）
+- **対象**: 開発チーム
+- **機能**:
+  - 最大10ユーザー
+  - チーム管理機能
+  - 使用状況分析
+  - セキュリティ機能
+
+## 対応言語・プラットフォーム
+
+### 対応プログラミング言語
+- **主要言語**: Python, JavaScript, TypeScript, Java, C++, C#, Go, Rust
+- **Web開発**: React, Vue.js, Angular, Next.js, Nuxt.js
+- **バックエンド**: Node.js, Django, Flask, Spring Boot, .NET
+- **モバイル**: React Native, Flutter, Swift, Kotlin
+- **データサイエンス**: R, Julia, MATLAB, TensorFlow, PyTorch
+
+### 対応プラットフォーム・ツール
+- **OS**: Linux, macOS, Windows
+- **クラウド**: AWS, Azure, Google Cloud, DigitalOcean
+- **コンテナ**: Docker, Kubernetes
+- **データベース**: PostgreSQL, MySQL, MongoDB, Redis
+- **CI/CD**: GitHub Actions, GitLab CI, Jenkins
+
+## インストール・設定方法
+
+### 1. アクセス申請
+```bash
+# 1. Cognition社のウェブサイトでアクセス申請
+# https://www.cognition-labs.com/
+
+# 2. 開発者情報とプロジェクト概要を提出
+# 3. 審査後の招待メールを待つ
+```
+
+### 2. 初期設定
+```bash
+# 招待メールからアクセス
+# 1. アカウント作成
+# 2. 開発環境の設定
+# 3. APIキーの取得
+```
+
+### 3. 開発環境の設定
+```yaml
+# devin-config.yaml
+version: "1.0"
+environment:
+  name: "my-project"
+  type: "web-application"
+  stack: "react-typescript-node"
+
+devin:
+  model: "latest"
+  autonomy_level: "full"
+  learning_enabled: true
+  debugging_enabled: true
+
+tools:
+  browser: true
+  terminal: true
+  ide: true
+  git: true
+  docker: true
+
+security:
+  api_key_management: true
+  code_review: true
+  dependency_scan: true
+```
+
+### 4. IDE統合
+```json
+// VS Code settings.json
+{
+  "devin.enabled": true,
+  "devin.autonomy": "full",
+  "devin.learning": true,
+  "devin.debugging": true,
+  "devin.api_key": "your-api-key-here"
+}
+```
+
+## 基本的な使い方
+
+### 1. プロジェクト作成
+```bash
+# 自然言語でのプロジェクト要求
+devin create "ECサイトを作成して。React + TypeScript + Node.js + PostgreSQLを使用"
+
+# 特定の要件での作成
+devin create --requirements requirements.txt --stack "react-node-postgres"
+```
+
+### 2. 機能実装
+```bash
+# 機能の追加
+devin implement "ユーザー認証機能を追加"
+
+# 特定のファイルの実装
+devin implement --file src/auth.ts "JWT認証を実装"
+
+# テスト付きで実装
+devin implement --with-tests "ユーザー登録API"
+```
+
+### 3. デバッグ・修正
+```bash
+# 自動デバッグ
+devin debug
+
+# 特定のエラーの修正
+devin fix "TypeError: Cannot read property 'name' of undefined"
+
+# パフォーマンス問題の解決
+devin optimize --performance
+```
+
+### 4. テスト・デプロイ
+```bash
+# テストの実行
+devin test
+
+# デプロイメント
+devin deploy --platform "vercel"
+
+# CI/CDパイプラインの設定
+devin setup-ci --platform "github-actions"
+```
+
+## 高度な機能
+
+### 1. プロジェクト分析・設計
+```bash
+# 既存プロジェクトの分析
+devin analyze --project ./existing-project
+
+# アーキテクチャ設計
+devin design --architecture "microservices" --services "user,product,order"
+
+# データベース設計
+devin design --database --schema schema.png
+```
+
+### 2. リファクタリング・最適化
+```bash
+# 自動リファクタリング
+devin refactor --strategy "extract-methods"
+
+# パフォーマンス最適化
+devin optimize --target "database-queries"
+
+# セキュリティ強化
+devin secure --scan "vulnerabilities"
+```
+
+### 3. 学習・適応
+```bash
+# 新しい技術の学習
+devin learn --technology "GraphQL"
+
+# プロジェクト固有の学習
+devin learn --project --patterns
+
+# ベストプラクティスの適用
+devin apply --best-practices
+```
+
+### 4. プロジェクト管理
+```bash
+# タスクの分割
+devin plan --tasks "user-authentication"
+
+# 進捗の追跡
+devin status --project
+
+# 依存関係の管理
+devin manage --dependencies
+```
+
+## ベストプラクティス
+
+### 1. 効果的なプロンプト設計
+```bash
+# 良い例：具体的で段階的な指示
+devin create "React + TypeScriptでECサイトを作成。ユーザー認証、商品管理、注文機能を含む。PostgreSQLでデータベース、Stripeで決済"
+
+# 悪い例：曖昧な指示
+devin create "ウェブサイトを作って"
+```
+
+### 2. セキュリティ考慮事項
+```yaml
+# devin-config.yaml でのセキュリティ設定
+security:
+  api_key_management: true
+  code_review: true
+  dependency_scan: true
+  vulnerability_scan: true
+  secrets_detection: true
+  sql_injection_protection: true
+```
+
+### 3. 品質管理
+```bash
+# コード品質の自動チェック
+devin quality --check
+
+# テストカバレッジの確保
+devin test --coverage --minimum 80
+
+# ドキュメントの自動生成
+devin document --generate
+```
+
+### 4. チーム開発での活用
+```yaml
+# チーム設定例
+team:
+  code_review_required: true
+  test_coverage_minimum: 80
+  security_scan_required: true
+  documentation_required: true
+  deployment_approval: true
+```
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+#### 1. 実行エラー
+```bash
+# ログの確認
+devin logs --verbose
+
+# 設定の検証
+devin validate --config
+
+# 環境の診断
+devin diagnose --environment
+```
+
+#### 2. パフォーマンス問題
+```yaml
+# devin-config.yaml での最適化設定
+performance:
+  batch_size: 100
+  parallel_execution: true
+  cache_enabled: true
+  model_optimization: true
+  memory_management: true
+```
+
+#### 3. 学習・適応の問題
+```bash
+# 学習データの確認
+devin learn --status
+
+# 適応能力のリセット
+devin learn --reset
+
+# カスタム学習データの追加
+devin learn --custom --data ./custom-data
+```
+
+## 他ツールとの比較
+
+### Devin vs GitHub Copilot
+| 項目 | Devin | GitHub Copilot |
+|------|-------|----------------|
+| 自律性 | 完全自律 | 補完のみ |
+| スコープ | プロジェクト全体 | ファイル単位 |
+| 実行能力 | 自動実行 | 手動実行のみ |
+| 学習能力 | 高度な適応学習 | 制限的 |
+| プロジェクト管理 | 内蔵 | なし |
+
+### Devin vs Coding Agent
+| 項目 | Devin | Coding Agent |
+|------|-------|--------------|
+| 自律性 | 完全自律 | 半自律 |
+| 実行環境 | クラウド中心 | ローカル・クラウド |
+| 学習能力 | 高度 | 中程度 |
+| プロジェクト管理 | 高度 | 基本 |
+| カスタマイズ | 制限的 | 高度 |
+
+### Devin vs Amazon CodeWhisperer
+| 項目 | Devin | Amazon CodeWhisperer |
+|------|-------|---------------------|
+| 自律性 | 完全自律 | 補完のみ |
+| 統合 | マルチプラットフォーム | AWS特化 |
+| 機能 | 包括的開発支援 | コード補完中心 |
+| 学習能力 | 高度 | 制限的 |
+| プロジェクト管理 | 内蔵 | なし |
+
+## まとめ
+
+Devinは、AIソフトウェアエンジニアとして、従来のAIコーディングアシスタントを超えた革新的な開発体験を提供します。完全に自律的な開発能力により、開発者の生産性を飛躍的に向上させ、複雑なプロジェクトも効率的に実行できます。
+
+### 推奨する導入ステップ
+1. **アクセス申請と審査**
+2. **小規模プロジェクトでのテスト**
+3. **段階的な機能活用**
+4. **チームでの導入検討**
+5. **継続的な最適化**
+
+Devinを活用することで、開発の自動化、品質の向上、開発速度の加速を実現できます。ただし、適切な設定とベストプラクティスの実践、そして人間の監督が重要です。
+
+### 今後の展望
+- **技術スタックの拡張**: より多くの言語・フレームワークへの対応
+- **学習能力の向上**: より高度な適応学習機能
+- **チーム協業**: 複数のDevinエージェント間の協調
+- **エンタープライズ機能**: 大規模組織での活用支援
+
+Devinは、ソフトウェア開発の未来を変える可能性を秘めた革新的なツールです。


### PR DESCRIPTION
Add comprehensive guides for GitHub Copilot, Coding Agent, and Devin to `docs/ai` to fulfill the user's request for detailed documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-f55aeb8a-3e71-4d47-b498-e1d00812a91f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f55aeb8a-3e71-4d47-b498-e1d00812a91f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

