### PR TITLE
feat: ナビゲーションリンクのパスを日本語から英語に変更

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -26,43 +26,43 @@ const vitePressOptions: UserConfig = {
     nav: [
       { text: 'ホーム', link: '/' },
       { text: 'AI', link: '/ai/' },
-      { 
-        text: 'Ruby', 
+      {
+        text: 'Ruby',
         items: [
-          { text: '1. Ruby基礎', link: '/ruby/#_1-ruby%E5%9F%BA%E7%A4%8E' },
-          { text: '2. Ruby応用', link: '/ruby/#_2-ruby%E5%BF%9C%E7%94%A8' },
-          { text: '3. Rubyエコシステム', link: '/ruby/#_3-ruby%E3%82%A8%E3%82%B3%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0' },
-          { text: '4. 発展トピック', link: '/ruby/#_4-ruby%E7%99%BA%E5%B1%95%E3%83%88%E3%83%94%E3%83%83%E3%82%AF' },
-          { text: '5. 実践・その他', link: '/ruby/#_5-%E5%AE%9F%E8%B7%B5-%E3%81%9D%E3%81%AE%E4%BB%96' }
+          { text: '1. Ruby基礎', link: '/ruby/#basics' },
+          { text: '2. Ruby応用', link: '/ruby/#applications' },
+          { text: '3. Rubyエコシステム', link: '/ruby/#ecosystem' },
+          { text: '4. 発展トピック', link: '/ruby/#advanced' },
+          { text: '5. 実践・その他', link: '/ruby/#practice' }
         ]
       },
-      { 
-        text: 'Rails', 
+      {
+        text: 'Rails',
         items: [
-          { text: '1. Rails基礎', link: '/rails/#_1-rails%E5%9F%BA%E7%A4%8E' },
-          { text: '2. Active Record / データベース', link: '/rails/#_2-active-record-%E3%83%86%E3%82%99%E3%83%BC%E3%82%BF%E3%83%98%E3%82%99%E3%83%BC%E3%82%B9' },
-          { text: '3. View / フロントエンド', link: '/rails/#_3-view-%E3%83%95%E3%83%AD%E3%83%B3%E3%83%88%E3%82%A8%E3%83%B3%E3%83%88%E3%82%99' },
-          { text: '4. Controller / ルーティング', link: '/rails/#_4-controller-%E3%83%AB%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%AF%E3%82%99' },
-          { text: '5. テスト', link: '/rails/#_5-%E3%83%86%E3%82%B9%E3%83%88' },
-          { text: '6. パフォーマンス', link: '/rails/#_6-%E3%83%8F%E3%82%9A%E3%83%95%E3%82%A9%E3%83%BC%E3%83%9E%E3%83%B3%E3%82%B9' },
-          { text: '7. アーキテクチャ / 設計', link: '/rails/#_7-%E3%82%A2%E3%83%BC%E3%82%AD%E3%83%86%E3%82%AF%E3%83%81%E3%83%A3-%E8%A8%AD%E8%A8%88' },
-          { text: '8. デプロイ / DevOps', link: '/rails/#_8-%E3%83%86%E3%82%99%E3%83%95%E3%82%9A%E3%83%AD%E3%82%A4-devops' },
-          { text: '9. API', link: '/rails/#_9-api' },
-          { text: '10. セキュリティ', link: '/rails/#_10-%E3%82%BB%E3%82%AD%E3%83%A5%E3%83%AA%E3%83%86%E3%82%A3' },
-          { text: '11. バックグラウンドジョブ', link: '/rails/#_11-%E3%83%8F%E3%82%99%E3%83%83%E3%82%AF%E3%82%AF%E3%82%99%E3%83%A9%E3%82%A6%E3%83%B3%E3%83%88%E3%82%99%E3%82%B7%E3%82%99%E3%83%A7%E3%83%95%E3%82%99' },
-          { text: '12. Gem / ライブラリ', link: '/rails/#_12-gem-%E3%83%A9%E3%82%A4%E3%83%95%E3%82%99%E3%83%A9%E3%83%AA' },
-          { text: '13. その他', link: '/rails/#_13-%E3%81%9D%E3%81%AE%E4%BB%96' },
+          { text: '1. Rails基礎', link: '/rails/#basics' },
+          { text: '2. Active Record / データベース', link: '/rails/#active-record-database' },
+          { text: '3. View / フロントエンド', link: '/rails/#view-frontend' },
+          { text: '4. Controller / ルーティング', link: '/rails/#controller-routing' },
+          { text: '5. テスト', link: '/rails/#testing' },
+          { text: '6. パフォーマンス', link: '/rails/#performance' },
+          { text: '7. アーキテクチャ / 設計', link: '/rails/#architecture-design' },
+          { text: '8. デプロイ / DevOps', link: '/rails/#deployment-devops' },
+          { text: '9. API', link: '/rails/#api' },
+          { text: '10. セキュリティ', link: '/rails/#security' },
+          { text: '11. バックグラウンドジョブ', link: '/rails/#background-jobs' },
+          { text: '12. Gem / ライブラリ', link: '/rails/#gems-libraries' },
+          { text: '13. その他', link: '/rails/#others' },
         ]
       },
-      { 
-        text: 'TypeScript', 
+      {
+        text: 'TypeScript',
         items: [
-          { text: '1. TypeScript基礎', link: '/typescript/#_1-typescript%E5%9F%BA%E7%A4%8E' },
-          { text: '2. TypeScript発展', link: '/typescript/#_2-typescript%E7%99%BA%E5%B1%95' },
-          { text: '3. TypeScriptエコシステム', link: '/typescript/#_3-typescript%E3%82%A8%E3%82%B3%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0' },
-          { text: '4. フレームワークとの連携', link: '/typescript/#_4-%E3%83%95%E3%83%AC%E3%83%BC%E3%83%A0%E3%83%AF%E3%83%BC%E3%82%AF%E3%81%A8%E3%81%AE%E9%80%A3%E6%90%BA' },
-          { text: '5. 開発ツールと効率化', link: '/typescript/#_5-%E9%96%8B%E7%99%BA%E3%83%84%E3%83%BC%E3%83%AB%E3%81%A8%E5%8A%B9%E7%8E%87%E5%8C%96' },
-          { text: '6. 実践・応用例', link: '/typescript/#_6-%E5%AE%9F%E8%B7%B5-%E5%BF%9C%E7%94%A8%E4%BE%8B' },
+          { text: '1. TypeScript基礎', link: '/typescript/#basics' },
+          { text: '2. TypeScript発展', link: '/typescript/#advanced' },
+          { text: '3. TypeScriptエコシステム', link: '/typescript/#ecosystem' },
+          { text: '4. フレームワークとの連携', link: '/typescript/#frameworks' },
+          { text: '5. 開発ツールと効率化', link: '/typescript/#tools' },
+          { text: '6. 実践・応用例', link: '/typescript/#practice' },
         ]
       },
       { text: 'GraphQL', link: '/graphql/' },

--- a/docs/rails/index.md
+++ b/docs/rails/index.md
@@ -2,7 +2,7 @@
 
 Ruby on Railsに関する技術記事をトピック別にまとめました。
 
-### 1. Rails基礎
+### 1. Rails基礎 {#basics}
 - [x] [Rails7対応！`rails new`から始めるブログアプリケーション開発チュートリアル](/rails/01-rails-basics/01-rails7-blog-tutorial)
 - [x] [Scaffoldは一体何をしているのか？生成されるコードを1行ずつ解説](/rails/01-rails-basics/02-scaffold-deep-dive)
 - [x] [Rails開発が捗る！`rails console`の便利な使い方10選](/rails/01-rails-basics/06-rails-console-tips)
@@ -15,7 +15,7 @@ Ruby on Railsに関する技術記事をトピック別にまとめました。
 - [x] [Rails 8の新機能と変更点を総まとめ: 開発者が知るべきポイント](/rails/01-rails-basics/67-rails8-new-features)
 - [x] [Rails初心者のためのMVCアーキテクチャ完全理解ガイド](/rails/01-rails-basics/77-mvc-architecture-guide)
 
-### 2. Active Record / データベース
+### 2. Active Record / データベース {#active-record-database}
 - [x] [Active Recordの基本: `has_many` / `belongs_to` を使って記事とコメント機能を実装する](/rails/02-active-record-database/03-active-record-associations)
 - [x] [Active Recordバリデーション入門: よく使う検証とカスタムバリデーションの作り方](/rails/02-active-record-database/05-active-record-validations)
 - [x] [ポリモーフィック関連を理解する: いいね機能やコメント機能を複数のモデルに対応させる方法](/rails/02-active-record-database/18-polymorphic-associations)
@@ -33,7 +33,7 @@ Ruby on Railsに関する技術記事をトピック別にまとめました。
 - [x] [Rails Active RecordとLaravel Eloquentのマイグレーション機能比較: スキーマ管理の違いと実装方法](/rails/02-active-record-database/92-rails-laravel-migration-comparison.md)
 - [x] [Rails Active StorageとLaravel Filesystemのファイルアップロード機能比較: 実装方法と特徴の違い](/rails/02-active-record-database/93-rails-laravel-file-upload-comparison.md)
 
-### 3. View / フロントエンド
+### 3. View / フロントエンド {#view-frontend}
 - [x] [Viewの基本: `form_with` を使って安全なフォームを作成する方法](/rails/03-view-frontend/07-rails-form-with)
 - [x] [Hotwire（Turbo/Stimulus）で作る、SPAのようなUXを持つ動的アプリケーション](/rails/03-view-frontend/16-hotwire-intro)
 - [x] [Action Cableを使ってリアルタイムなチャット機能を実装する](/rails/03-view-frontend/17-action-cable-chat)
@@ -50,11 +50,11 @@ Ruby on Railsに関する技術記事をトピック別にまとめました。
 - [x] [Turbo Streamsでリアルタイム更新を実現する高度なテクニック](/rails/03-view-frontend/71-advanced-turbo-streams)
 - [x] [`Motion UI`と`Turbo`を連携させたリッチなUIアニメーション](/rails/03-view-frontend/88-motion-ui-turbo-guide)
 
-### 4. Controller / ルーティング
+### 4. Controller / ルーティング {#controller-routing}
 - [x] [もう怖くない！Railsのルーティング (`routes.rb`) 完全ガイド](/rails/04-controller-routing/04-rails-routing-guide)
 - [x] [Rails 8のコントローラレイヤー改善と新しいレスポンス処理](/rails/04-controller-routing/72-rails8-controller-improvements)
 
-### 5. テスト
+### 5. テスト {#testing}
 - [x] [Rails標準のテストフレームワーク「Minitest」ではじめるテスト駆動開発（TDD）](/rails/05-testing/13-minitest-tdd-intro)
 - [x] [RSpecとFactoryBotを使った実践的なテストコードの書き方](/rails/05-testing/28-rspec-factorybot)
 - [x] [System Spec（E2Eテスト）をCapybaraで書く実践ガイド](/rails/05-testing/51-capybara-system-spec)
@@ -63,7 +63,7 @@ Ruby on Railsに関する技術記事をトピック別にまとめました。
 - [x] [Rails 8時代のテスト戦略: 新機能を活用したテストの書き方](/rails/05-testing/73-rails8-testing-strategy)
 - [x] [`RSpec Mocks`の高度な使い方: `double`, `spy`, `stub`の活用](/rails/05-testing/87-rspec-mocks-guide)
 
-### 6. パフォーマンス
+### 6. パフォーマンス {#performance}
 - [x] [N+1問題はこれで解決！Bullet gemの導入と実践的な使い方](/rails/06-performance/09-n-plus-one-with-bullet)
 - [x] [Active Recordクエリの高速化: `joins`, `preload`, `includes`, `eager_load` の違いと使い分け](/rails/06-performance/10-active-record-query-optimization)
 - [x] [パフォーマンスチューニング: Railsアプリケーションのボトルネックを特定し、改善する実践テクニック](/rails/06-performance/20-performance-tuning)
@@ -72,14 +72,14 @@ Ruby on Railsに関する技術記事をトピック別にまとめました。
 - [x] [Rails 8のパフォーマンス改善: ベンチマークから見る実際の効果](/rails/06-performance/74-rails8-performance-improvements)
 - [x] [`rack-mini-profiler`による開発中のパフォーマンス計測](/rails/06-performance/86-rack-mini-profiler-guide)
 
-### 7. アーキテクチャ / 設計
+### 7. アーキテクチャ / 設計 {#architecture-design}
 - [x] [サービスクラス（Service Object）を導入してFat Controllerを解消する](/rails/07-architecture-design/08-service-objects-for-fat-controllers)
 - [x] [Rails Engineを作成して、再利用可能なコンポーネントを開発する](/rails/07-architecture-design/19-rails-engines)
 - [x] [Trailblazerアーキテクチャを導入して大規模Railsアプリケーションを構築する](/rails/07-architecture-design/57-trailblazer-architecture)
 - [x] [Railsアプリケーションにおけるマイクロサービス化への道筋](/rails/07-architecture-design/59-rails-microservices)
 - [x] [Railsにおけるドメイン駆動設計(DDD)入門](/rails/07-architecture-design/85-rails-ddd-guide)
 
-### 8. デプロイ / DevOps
+### 8. デプロイ / DevOps {#deployment-devops}
 - [x] [Docker Composeを使ったRails開発環境の構築とメリット](/rails/08-deployment-devops/24-docker-compose-rails-development)
 - [x] [Render.comへRailsアプリケーションをデプロイする2025年版ガイド](/rails/08-deployment-devops/26-deploy-rails-to-render)
 - [x] [RailsアプリケーションのCI/CDパイプラインをGitHub Actionsで構築する](/rails/08-deployment-devops/39-rails-ci-github-actions)
@@ -89,14 +89,14 @@ Ruby on Railsに関する技術記事をトピック別にまとめました。
 - [x] [VercelでRailsアプリケーションをデプロイする2025年版ガイド](/rails/08-deployment-devops/87-deploy-rails-to-vercel)
 - [x] [Google CloudでRailsアプリケーションをデプロイする2025年版ガイド](/rails/08-deployment-devops/88-deploy-rails-to-google-cloud)
 
-### 9. API
+### 9. API {#api}
 - [x] [Ruby on RailsのAPIモード](/rails/09-api/08-rails-api-mode)
 - [x] [GraphQL APIを`graphql-ruby` gemで構築する](/rails/09-api/25-graphql-ruby-api)
 - [x] [Rails APIモード + Next.jsで構築するモダンなWebアプリケーション](/rails/09-api/27-rails-api-nextjs)
 - [x] [RailsにおけるAPIドキュメントの自動生成 (RSwag/Committee)](/rails/09-api/45-rails-api-documentation)
 - [x] [RailsとgRPCによるハイパフォーマンスなマイクロサービス間通信](/rails/09-api/83-rails-grpc-guide)
 
-### 10. セキュリティ
+### 10. セキュリティ {#security}
 - [x] [Devise gemを使わずに自前で認証機能を実装する](/rails/10-security/14-authentication-from-scratch)
 - [x] [Railsセキュリティ: OWASP Top 10に基づいた脆弱性対策と実践](/rails/10-security/30-rails-security-owasp)
 - [x] [Punditを使った認可機能の実装: ポリシーベースのアクセス制御](/rails/10-security/37-pundit-authorization)
@@ -104,13 +104,13 @@ Ruby on Railsに関する技術記事をトピック別にまとめました。
 - [x] [Action Policy: Punditに代わる次世代の認可ライブラリ](/rails/10-security/65-action-policy-authorization)
 - [x] [`Brakeman`による静的解析での脆弱性診断](/rails/10-security/82-brakeman-guide)
 
-### 11. バックグラウンドジョブ
+### 11. バックグラウンドジョブ {#background-jobs}
 - [x] [Sidekiqではじめるバックグラウンドジョブ入門](/rails/11-background-jobs/11-introduction-to-sidekiq)
 - [x] [Active Job詳解: アダプターの選び方と高度な使い方](/rails/11-background-jobs/35-active-job-guide)
 - [x] [RailsとGoodJob: PostgreSQLベースのバックグラウンドジョブプロセッサ](/rails/11-background-jobs/63-goodjob-background-jobs)
 - [x] [`Sidekiq-cron`で定期的なジョブをスケジューリングする](/rails/11-background-jobs/81-sidekiq-cron-guide)
 
-### 12. Gem / ライブラリ
+### 12. Gem / ライブラリ {#gems-libraries}
 - [x] [Sorbetを導入してRailsアプリケーションに型を導入する](/rails/12-gems-libraries/29-sorbet-rails)
 - [x] [RailsとStripe連携: サブスクリプション課金システムを構築する](/rails/12-gems-libraries/31-rails-stripe-subscription)
 - [x] [Avo/Administrate/Trestle: Rails製管理画面gemの比較と選択](/rails/12-gems-libraries/38-rails-admin-gems-comparison)
@@ -120,7 +120,7 @@ Ruby on Railsに関する技術記事をトピック別にまとめました。
 - [x] [Shopify LiquidテンプレートエンジンをRailsで活用する](/rails/12-gems-libraries/75-shopify-liquid-rails)
 - [x] [`CanCanCan`によるシンプルで強力な認可管理](/rails/12-gems-libraries/80-cancancan-guide)
 
-### 13. その他
+### 13. その他 {#others}
 - [x] [Rackミドルウェアを自作してリクエスト/レスポンスをカスタマイズする](/rails/13-others/21-custom-rack-middleware)
 - [x] [Rails開発者のためのDocker最適化テクニック集](/rails/13-others/76-docker-optimization-rails)
 - [x] [`i18n-tasks` gemでRailsの多言語対応を効率化する](/rails/13-others/79-i18n-tasks-guide)

--- a/docs/ruby/index.md
+++ b/docs/ruby/index.md
@@ -1,6 +1,6 @@
 # Ruby技術記事
 
-## 1. Ruby基礎
+## 1. Ruby基礎 {#basics}
 
 - [x] [Rubyのインストールとバージョン管理](./01-basics/01-ruby-setup.md)
 - [x] [Rubyの基本構文](./01-basics/02-ruby-syntax.md)
@@ -14,7 +14,7 @@
 - [x] [Rubyの委譲（Delegation）](./01-basics/09-ruby-delegation.md)
 - [x] [Ruby 3.xの主要な新機能](./01-basics/31-ruby3-new-features.md)
 
-## 2. Ruby応用
+## 2. Ruby応用 {#applications}
 
 - [x] [Ruby製CLIツールの作り方](./02-applications/03-cli-tool-creation.md)
 - [x] [RubyのSocketプログラミング](./02-applications/07-socket-programming.md)
@@ -29,7 +29,7 @@
 - [x] [RubyとC言語連携（拡張ライブラリ作成）](./02-applications/35-ruby-c-extension.md)
 - [x] [RubyのDSL（ドメイン固有言語）作成法](./02-applications/39-ruby-dsl-creation.md)
 
-## 3. Rubyエコシステム
+## 3. Rubyエコシステム {#ecosystem}
 
 - [x] [BundlerによるGemの依存関係管理](./03-ecosystem/15-bundler-gem-management.md)
 - [x] [Rakeタスクの作り方と活用法](./03-ecosystem/16-rake-tasks.md)
@@ -42,7 +42,7 @@
 - [x] [RubyによるWebスクレイピング](./03-ecosystem/37-ruby-web-scraping.md)
 - [x] [Ruby製静的サイトジェネレータ](./03-ecosystem/38-ruby-static-site-generators.md)
 
-## 4. 発展トピック
+## 4. 発展トピック {#advanced}
 
 - [x] [RBSによる型定義](./04-advanced/02-rbs-type-definition.md)
 - [x] [Rubyのリフレクション機能](./04-advanced/06-ruby-reflection.md)
@@ -59,7 +59,7 @@
 - [x] [mruby/CRubyの違い](./04-advanced/30-mruby-vs-cruby.md)
 - [x] [Ruby on Railsのセキュリティベストプラクティス](./04-advanced/40-rails-security-best-practices.md)
 
-## 5. 実践・その他
+## 5. 実践・その他 {#practice}
 
 - [x] [Prismパーサー: Rubyの新しいデフォルトパーサー](./05-others/01-prism-parser.md)
 - [x] [Garnet VM: 次世代Ruby仮想マシン](./05-others/02-garnet-vm.md)

--- a/docs/typescript/index.md
+++ b/docs/typescript/index.md
@@ -1,6 +1,6 @@
 # TypeScript技術記事
 
-## 1. TypeScript基礎
+## 1. TypeScript基礎 {#basics}
 
 - [x] [TypeScriptのインストールとセットアップ](./01-basics/01-typescript-setup.md)
 - [x] [TypeScriptの基本構文](./01-basics/02-typescript-syntax.md)
@@ -12,7 +12,7 @@
 - [x] [ユニオン型とインターセクション型](./01-basics/08-union-and-intersection-types.md)
 - [x] [型エイリアスとタイプガード](./01-basics/09-type-aliases-and-type-guards.md)
 - [x] [ジェネリクスの基礎](./01-basics/10-generics-basics.md)
-## 2. TypeScript発展
+## 2. TypeScript発展 {#advanced}
 
 - [x] [高度なジェネリクス](./02-advanced/01-advanced-generics.md)
 - [x] [条件型（Conditional Types）](./02-advanced/02-conditional-types.md)
@@ -25,7 +25,7 @@
 - [ ] [TypeScriptの型システムの内部動作]
 - [ ] [パフォーマンス最適化のための型設計]
 
-## 3. TypeScriptエコシステム
+## 3. TypeScriptエコシステム {#ecosystem}
 
 - [ ] [TSConfigの詳細設定]
 - [ ] [TypeScript Compilerの使い方]
@@ -38,7 +38,7 @@
 - [ ] [TypeScript向けのビルドツール比較]
 - [ ] [TypeScript Node.js開発環境]
 
-## 4. フレームワークとの連携
+## 4. フレームワークとの連携 {#frameworks}
 
 - [x] [React + TypeScript](./04-frameworks/01-react-typescript.md)
 - [ ] [Vue.js + TypeScript]
@@ -51,7 +51,7 @@
 - [ ] [tRPC TypeScript API]
 - [ ] [Prisma + TypeScript]
 
-## 5. 開発ツールと効率化
+## 5. 開発ツールと効率化 {#tools}
 
 - [ ] [TypeScript Language Server]
 - [ ] [VS Code TypeScript開発]
@@ -64,7 +64,7 @@
 - [ ] [TypeScript Playground活用法]
 - [ ] [TypeScript パッケージ管理のベストプラクティス]
 
-## 6. 実践・応用例
+## 6. 実践・応用例 {#practice}
 
 - [ ] [型安全なAPI設計パターン]
 - [ ] [TypeScriptでのエラーハンドリング]


### PR DESCRIPTION
- Ruby、Rails、TypeScriptの各index.mdにカスタム英語アンカーIDを追加
- config.mtsのナビゲーションリンクをURLエンコードされた日本語パスから英語パスに変更
- より読みやすく、URLフレンドリーなパスに改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)