### PR TITLE
chore: MCP用のGCP認証情報と設定ファイルをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ node_modules
 
 # GitHub App credentials
 gha-creds-*.json
+
+# GCP service account key (MCP用)
+.gcp/
+
+# MCP settings (ローカルの絶対パスを含むため)
+.mcp.json


### PR DESCRIPTION
## 概要

Google Analytics / Search Console の MCP サーバーをローカルで利用するにあたり、秘匿情報と環境依存ファイルを追跡対象外にします。

## 変更内容

`.gitignore` に以下を追加:

- `.gcp/` — サービスアカウントキー（`.gcp/sa.json`）の置き場
- `.mcp.json` — MCPサーバー定義。ローカルの絶対パスを含むため

## 補足

- キー本体はコミットされていないことを `git check-ignore` で確認済み
- リポジトリに追加されるファイルは `.gitignore` の6行のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNsdRu9DmWfyt5j5jKDS5J