### PR TITLE
canonicalタグを全ページに追加（.htmlあり/なしの重複URL解消）

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,6 +5,17 @@ import { VitePressSidebarOptions } from 'vitepress-sidebar/types'
 import fs from 'fs'
 import path from 'path'
 
+const HOSTNAME = 'https://ai-techblog.okdyy75.com'
+
+// GitHub Pages は `/foo` と `/foo.html` の両方を 200 で返すため、
+// canonical を出さないと全記事が重複URL扱いになる。出力ファイル名に合わせて `.html` を正とする
+function canonicalUrl(relativePath: string) {
+  const p = relativePath
+    .replace(/(^|\/)index\.md$/, '$1')
+    .replace(/\.md$/, '.html')
+  return `${HOSTNAME}/${p}`
+}
+
 function generateNav() {
   const docsDir = path.join(__dirname, '..')
   const categories = [
@@ -44,7 +55,14 @@ const vitePressOptions: UserConfig = {
   title: "AIテックブログ",
   description: "AIが自動生成した技術記事をまとめたテックブログです",
   sitemap: {
-    hostname: 'https://ai-techblog.okdyy75.com'
+    hostname: HOSTNAME
+  },
+  transformPageData(pageData) {
+    const head = (pageData.frontmatter.head ?? []).filter(
+      (h) => !(h[0] === 'link' && h[1]?.rel === 'canonical')
+    )
+    head.push(['link', { rel: 'canonical', href: canonicalUrl(pageData.relativePath) }])
+    pageData.frontmatter.head = head
   },
     head: [
         ["script", { async: "", src: "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9459277760652211", crossorigin: "anonymous" }],


### PR DESCRIPTION
分割PR **1/6**。ベース: `main`

## 問題

GitHub Pages は `/foo` と `/foo.html` の**両方を200で返す**。canonical タグがないため、全記事が2つのURLで重複扱いになっていた。

実際に Search Console 上で同一記事が別ページとして記録されていた。

```
/ai/10-mastering-ai-code-assistants        16表示 順位24.5
/ai/10-mastering-ai-code-assistants.html   25表示 順位32.4
```

## 対応

`transformPageData` で全ページに canonical を出力。出力ファイル名に合わせて `.html` を正とする。

```
記事:     .../rails/06-performance/09-n-plus-one-with-bullet.html
カテゴリ: .../graphql/
トップ:   .../
```

カテゴリ index はディレクトリ形式に寄せた（`/graphql/index.html` ではなく `/graphql/`）。

## 確認

```
HTML総数 259 / canonical付与 259 / 重複 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYTZZXkGGBdSXKkLh8Q3iY