### PR TITLE
lastUpdatedを有効化してサイトマップにlastmodを出力

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -54,6 +54,8 @@ function generateNav() {
 const vitePressOptions: UserConfig = {
   title: "AIテックブログ",
   description: "AIが自動生成した技術記事をまとめたテックブログです",
+  // git の最終コミット日を取得し、サイトマップの lastmod と記事下部の最終更新日に反映する
+  lastUpdated: true,
   sitemap: {
     hostname: HOSTNAME
   },


### PR DESCRIPTION
分割PR **2/6**。ベース: `seo/1-canonical`（#153）

## 問題

sitemap.xml が `<loc>` のみで `<lastmod>` を持たないため、更新が検知されにくい。Search Console 上のサイトマップ最終ダウンロードは 2025-11-19 で止まっている。

## 対応

**VitePress の標準機能で足りる**ので、`lastUpdated: true` を立てるだけにした。

`vitepress/dist/node` の `generateSitemap` は元々 lastmod を出力する実装を持っており、このフラグだけがゲートになっている。

```js
const getLastmod = async (url) => {
  if (!siteConfig.lastUpdated) return undefined;   // ← ここ
  ...
  return await getGitTimestamp(file) || undefined;
};
```

当初 `git log` を自前で走査する実装（+37行）を書いていたが、標準機能と結果が完全に一致したため破棄した。あわせて `x/index.html` → `x/` のURL正規化も入れていたが、VitePress 側が既に `page.replace(/(^|\/)index\.md$/, "$1")` で処理済みで**デッドコードだった**ため削除した。

## 副次効果

記事下部に最終更新日が表示されるようになる（258ページ）。更新日が見えることは品質面のシグナルとしても有効で、手動対策への対応という文脈でも都合がよい。

## 確認

```
sitemap URL数 259 / lastmod数 259 / index.html形式の残存 0
例: <loc>.../graphql/</loc><lastmod>2026-04-08T20:06:18.000Z</lastmod>
ビルド時間 20.7s -> 21.4s（getGitTimestamp はファイル単位で spawn するがキャッシュされ、実用上の差はない）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYTZZXkGGBdSXKkLh8Q3iY