### PR TITLE
サイトマップにlastmodを出力する

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -57,6 +57,8 @@ const vitePressOptions: UserConfig = {
   sitemap: {
     hostname: HOSTNAME
   },
+  // git の最終コミット日を取得し、サイトマップの lastmod と記事下部の最終更新日に反映する
+  lastUpdated: true,
   transformPageData(pageData) {
     const head = (pageData.frontmatter.head ?? []).filter(
       (h) => !(h[0] === 'link' && h[1]?.rel === 'canonical')


### PR DESCRIPTION
**ベース: `main`。他のPRとは独立しており、単独でマージできます。**

## 問題

sitemap.xml が `<loc>` のみで `<lastmod>` を持たないため更新が検知されにくい。Search Console 上のサイトマップ最終ダウンロードは 2025-11-19 で止まっている。

## 対応

VitePress の標準機能で足りるため `lastUpdated: true` を立てるだけ。`generateSitemap` は元々 lastmod を出力する実装を持っており、このフラグがゲートになっている。

```js
const getLastmod = async (url) => {
  if (!siteConfig.lastUpdated) return undefined;   // ← ここ
  return await getGitTimestamp(file) || undefined;
};
```

副次効果として記事下部に最終更新日が表示される。更新日が見えることは品質面のシグナルとしても有効。

## 確認

```
sitemap URL数 259 / lastmod数 259
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYTZZXkGGBdSXKkLh8Q3iY