### PR TITLE
AI自動生成の記述を削除しAdSenseを停止

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -53,7 +53,7 @@ function generateNav() {
 // https://vitepress.dev/reference/site-config
 const vitePressOptions: UserConfig = {
   title: "AIテックブログ",
-  description: "AIが自動生成した技術記事をまとめたテックブログです",
+  description: "Ruby・Rails を中心に、Web 開発の技術記事をまとめたブログです",
   sitemap: {
     hostname: HOSTNAME
   },
@@ -65,7 +65,7 @@ const vitePressOptions: UserConfig = {
     pageData.frontmatter.head = head
   },
     head: [
-        ["script", { async: "", src: "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9459277760652211", crossorigin: "anonymous" }],
+        // AdSense は手動対策の解除まで停止（コンテンツポリシー面のリスク回避）
         ["script", { async: "", src: "https://www.googletagmanager.com/gtag/js?id=G-KV4CN8TQVS" }],
         [
             "script",
@@ -85,7 +85,7 @@ const vitePressOptions: UserConfig = {
     ],
 
     footer: {
-      message: 'AI が自動生成した技術記事をまとめたテックブログ',
+      message: 'Ruby・Rails を中心とした Web 開発の技術ブログ',
       copyright: 'Copyright © 2024 okdyy75'
     },
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 
 hero:
   name: "AIテックブログ"
-  text: "AIが自動生成した技術記事をまとめたテックブログです"
+  text: "Ruby・Rails を中心とした Web 開発の技術ブログ"
   tagline: "Ruby・Rails に特化した包括的な技術記事コレクション"
   actions:
     - theme: brand


### PR DESCRIPTION
**ベース: `main`。他のPRとは独立しており、単独でマージできます。**

## 問題

サイト説明3箇所に「AIが自動生成した技術記事をまとめた」と明記されていた。手動対策「価値のない質の低いコンテンツ」を受けている状況で、**これは自らスケールコンテンツであると申告している**状態で、再審査の際に不利に働く。

## 対応

扱うトピックの記述に置き換えた。**まだ事実でない主張（「検証済み」など）は足していない。**

```
before: AIが自動生成した技術記事をまとめたテックブログです
after:  Ruby・Rails を中心に、Web 開発の技術記事をまとめたブログです
```

対象は `docs/index.md` の hero、`config.mts` の `description` と footer の3箇所。

あわせて **AdSense を停止**した。Google のコンテンツポリシーは検索とAdSenseで地続きで、手動対策中のサイトに広告を載せ続けるのはアカウント側のリスクになる。

## 確認

```
AI自動生成の記述が残るページ 0 / AdSenseが残るページ 0
```

## 補足

AdSense は収益の話なので判断はお任せします。戻す場合は `config.mts` のコメント行を元のスクリプトタグに差し替えるだけです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYTZZXkGGBdSXKkLh8Q3iY